### PR TITLE
[#29] (Close예정) 메인 뷰 코디네이터 적용

### DIFF
--- a/Milestone/Milestone.xcodeproj/project.pbxproj
+++ b/Milestone/Milestone.xcodeproj/project.pbxproj
@@ -142,6 +142,7 @@
 		C90DC9882A891A8500241B7C /* OnboardingViewControllerLast.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90DC9872A891A8500241B7C /* OnboardingViewControllerLast.swift */; };
 		C90DC98A2A8922D300241B7C /* NSMutableAttributedString+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90DC9892A8922D300241B7C /* NSMutableAttributedString+.swift */; };
 		C90DC98C2A89C35D00241B7C /* CompletionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90DC98B2A89C35D00241B7C /* CompletionCoordinator.swift */; };
+		C90DC98E2A89EDE000241B7C /* MainCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90DC98D2A89EDE000241B7C /* MainCoordinator.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -221,6 +222,7 @@
 		C90DC9872A891A8500241B7C /* OnboardingViewControllerLast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewControllerLast.swift; sourceTree = "<group>"; };
 		C90DC9892A8922D300241B7C /* NSMutableAttributedString+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMutableAttributedString+.swift"; sourceTree = "<group>"; };
 		C90DC98B2A89C35D00241B7C /* CompletionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionCoordinator.swift; sourceTree = "<group>"; };
+		C90DC98D2A89EDE000241B7C /* MainCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainCoordinator.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -417,6 +419,7 @@
 		A2B9697F2A8574EA00C4903F /* Main */ = {
 			isa = PBXGroup;
 			children = (
+				C90DC98D2A89EDE000241B7C /* MainCoordinator.swift */,
 				A2B969802A8574F200C4903F /* View */,
 			);
 			path = Main;
@@ -808,6 +811,7 @@
 				A2FA59252A7FD3B1006ACA2E /* UICollectionView+.swift in Sources */,
 				A2D304C12A854EDE00A5BA92 /* MainSegmentedControl.swift in Sources */,
 				A2B20D9A2A7ED40D001ED73C /* Logger.swift in Sources */,
+				C90DC98E2A89EDE000241B7C /* MainCoordinator.swift in Sources */,
 				A2B20D592A7E4E5C001ED73C /* UIFont+.swift in Sources */,
 				A2B20D942A7ED174001ED73C /* UIImage+.swift in Sources */,
 				C90DC9822A88854C00241B7C /* OnboardingViewController.swift in Sources */,

--- a/Milestone/Milestone/Screens/Main/MainCoordinator.swift
+++ b/Milestone/Milestone/Screens/Main/MainCoordinator.swift
@@ -1,0 +1,82 @@
+//
+//  MainCoordinator.swift
+//  Milestone
+//
+//  Created by 박경준 on 2023/08/14.
+//
+
+import UIKit
+
+enum CoordinateDirection {
+    case previous
+    case after
+}
+
+protocol MainFlow {
+    func coordinateToCompletionBox(direction: UIPageViewController.NavigationDirection)
+    func coordinateToStorageBox(direction: UIPageViewController.NavigationDirection)
+    func coordinateToFillBox(direction: UIPageViewController.NavigationDirection)
+    func coordinate(to index: Int, direction: UIPageViewController.NavigationDirection)
+    func coordinate(to direction: CoordinateDirection)
+    var pageViewController: UIPageViewController? { get set }
+}
+
+class MainCoordinator: Coordinator, MainFlow {
+    
+    let navigationController: UINavigationController
+    var pageViewController: UIPageViewController?
+    
+    private let storageBoxVC = StorageBoxViewController()
+    private let fillBoxVC = FillBoxViewController()
+    private let completionVC = CompletionBoxViewController()
+    var viewControllers: [UIViewController] { [self.storageBoxVC, self.fillBoxVC, self.completionVC] }
+    
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+    func start() {
+        let mainVC = MainViewController()
+//        mainVC.coordinator = self
+        navigationController.navigationBar.isHidden = true
+        navigationController.pushViewController(mainVC, animated: true)
+    }
+    
+    func coordinate(to index: Int, direction: UIPageViewController.NavigationDirection) {
+        switch index {
+        case 0:
+            coordinateToStorageBox(direction: direction)
+        case 1:
+            coordinateToFillBox(direction: direction)
+        case 2:
+            coordinateToCompletionBox(direction: direction)
+        default:
+            break
+        }
+    }
+    
+    func coordinate(to direction: CoordinateDirection) {
+        switch direction {
+        case .after:
+            
+            print("after")
+        case .previous:
+            print("previ")
+        }
+    }
+    
+    func coordinateToFillBox(direction: UIPageViewController.NavigationDirection) {
+        pageViewController?.setViewControllers([fillBoxVC], direction: direction, animated: true)
+        print("FILL")
+    }
+    
+    func coordinateToStorageBox(direction: UIPageViewController.NavigationDirection) {
+        pageViewController?.setViewControllers([storageBoxVC], direction: direction, animated: true)
+        print("STORAGE")
+    }
+    
+    func coordinateToCompletionBox(direction: UIPageViewController.NavigationDirection) {
+        pageViewController?.setViewControllers([completionVC], direction: direction, animated: true)
+        print("COMPLETION")
+    }
+}

--- a/Milestone/Milestone/Screens/Onboarding/OnboardingCoordinator.swift
+++ b/Milestone/Milestone/Screens/Onboarding/OnboardingCoordinator.swift
@@ -33,6 +33,7 @@ class OnboardingCoordinator: Coordinator, OnboardingFlow {
     }
     
     func coordinateToMain() {
-        navigationController.pushViewController(MainViewController(), animated: true)
+        let mainCoordinator = MainCoordinator(navigationController: navigationController)
+        coordinate(to: mainCoordinator)
     }
 }


### PR DESCRIPTION
## 상세 내용

1. 메인뷰의 `UISegmentControl` & `UIPageViewController` 델리게이트 기반의 화면 전환 로직을 코디네이터에 위임하려고 시도했습니다.
2. `RxCocoa`의 델리게이트 프록시를 사용하면 코코아터치의 기본 델리게이트 & 데이터소스의 동작을 Rx로 전환할 수 있습니다.
3. `UIPageViewControllerDelegate`는 필수 구현 메서드가 없어서 괜찮은데, UIPageViewControllerDataSource`의 경우 두 개의 필수 구현 메서드가 존재합니다. 
4. Rx에서 델리게이트 프록시를 설정할때 코코아터치 델리게이트 메서드를 구현해버리면 중복 구현으로 인해 델리게이트 프록시 메서드들이 동작하지 않게 됩니다. 
5. 델리게이트 프록시 클래스 정의시에는 반드시 연관 프로토콜을 동일하게 채택해야합니다. 예를 들어 내가 Rx로 전환하고자 하는 프로토콜이 `UIPageViewControllerDataSource` 라면 델리게이트 프록시 클래스 역시 해당 프로토콜을 채택해야 합니다.
6. 필수 구현 함수가 구현되지 않은 한 컴파일 에러로 인해 빌드가 진행되지 않습니다.
7. 따라서 델리게이트 프록시에도 동일하게 필수 구현 메서드를 추가하고, `return nil`을 통해 기본 동작을 제어해두고 시작합니다.
8. 델리게이트 프록시에 `PublishSubject`를 두고 `UIPageViewController`를 베이스로 하는 `Reactive`클래스를 확장합니다.

```swift
    func pageViewController(_ pageViewController: UIPageViewController, viewControllerAfter viewController: UIViewController) -> UIViewController? {
        
        print(pageViewController.viewControllers)
        afterVC.onNext(viewController)
        
        return nil
    }
```

- Rx 내부 스트림 관리에 따라 프로토콜 메서드가 호출 되는 것으로 현재는 이해하고 있습니다. 보시면 afterVC라는 서브젝트에 next 이벤트로 뷰컨을 방출하는데, 이게 나중에 구독해서 확인해보면 실제로 데이터를 받아오더라구요

```swift
extension Reactive where Base: UIPageViewController {
    var dataSource: RxUIPageViewcontrollerDataSourceProxy {
        return RxUIPageViewcontrollerDataSourceProxy.proxy(for: base)
    }

    var pageViewControllerBefore: Observable<UIViewController> {
        return dataSource.previousVC
    }
    
    var pageViewControllerAfter: Observable<UIViewController> {
        return dataSource.afterVC
    }
}
```

1. 확장한 리액티브 클래스에 대해 rx속성으로 pageViewControllerBefore / pageViewControllerAfter라는 옵저버블 속성들을 각각 추가합니다.
2. 뷰 컨트롤러 내에서 구독해서 데이터를 활용하면 끗

## 실패 이유
1. 일단.. 굳이 코코아터치 프레임워크의 델리게이트 패턴을 버리고 프록시를 써서 Rx스럽게 변환해야만 이유를 제 스스로 납득하지 못해서 중도 포기했습니다ㅠ 
2. 코드를 작성하다보니 메인 뷰 코디네이터가 메인 뷰컨트롤러의 `UIPageViewController` 인스턴스를 참조해야만 하는 상황이 벌어지더라구요.. 메모리 관리가 두려워져서 중도 포기했습니다.

## 얻은 점
1. 델리게이트 프록시 정의 시 프로토콜 메서드가 필수 구현 대상일때, 옵저버블에 next이벤트를 전달하면 확장한 리액티브 클래스에서 알아서 데이터를 받아올 수 있다는 것
2. 탈모

<br/>

## 기타

<br/>

## 셀프 체크리스트
- [ ] Merge 하는 브랜치가 올바른가?
- [ ] 코딩 컨벤션을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 오른쪽의 Development에서 이슈와 연결하였는가?
