### PR TITLE
[#13] 채움함 UI 수정

### DIFF
--- a/Milestone/Milestone/Global/Extension/UIColor+.swift
+++ b/Milestone/Milestone/Global/Extension/UIColor+.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 extension UIColor {
-    static var primaty: UIColor {
+    static var primary: UIColor {
         return UIColor(hex: "#408DF2")
     }
     static var secondary01: UIColor {

--- a/Milestone/Milestone/Screens/FillBox/View/Cell/ParentGoalTableViewCell.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/Cell/ParentGoalTableViewCell.swift
@@ -60,7 +60,7 @@ class ParentGoalTableViewCell: BaseTableViewCell {
         self.containerView.layer.shadowColor = UIColor.init(hex: "#DCDCDC").cgColor
         self.containerView.layer.shadowOpacity = 1.0
         self.containerView.layer.shadowOffset = CGSize.zero
-        self.containerView.layer.shadowRadius = 7
+        self.containerView.layer.shadowRadius = 7 / 2.0
     }
     
     override func render() {
@@ -70,8 +70,8 @@ class ParentGoalTableViewCell: BaseTableViewCell {
         
         containerView.snp.makeConstraints { make in
             make.height.equalTo(96)
-            make.top.left.right.equalToSuperview()
-            make.bottom.equalToSuperview().inset(16)
+            make.top.bottom.equalToSuperview().inset(8)
+            make.left.right.equalToSuperview().inset(4)
         }
         
         goalStatusImageView.snp.makeConstraints { make in

--- a/Milestone/Milestone/Screens/FillBox/View/FillBoxViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/FillBoxViewController.swift
@@ -30,15 +30,15 @@ class FillBoxViewController: BaseViewController {
     
     lazy var addGoalButton = UIButton()
         .then {
-            $0.backgroundColor = .gray05
+            $0.backgroundColor = .primary
             $0.layer.cornerRadius = 64 / 2
             $0.setImage(ImageLiteral.imgPlus, for: .normal)
             $0.addTarget(self, action: #selector(addNewParentGoal), for: .touchUpInside)
             // 그림자 생성
-            $0.layer.shadowColor = UIColor.black.cgColor
-            $0.layer.shadowOpacity = 0.4
+            $0.layer.shadowColor = UIColor.primary.cgColor
+            $0.layer.shadowOpacity = 0.6
             $0.layer.shadowOffset = CGSize(width: 0, height: 4)
-            $0.layer.shadowRadius = 5
+            $0.layer.shadowRadius = 6 / 2.0
         }
     
     // MARK: - Properties

--- a/Milestone/Milestone/Screens/FillBox/View/FillBoxViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/FillBoxViewController.swift
@@ -50,7 +50,7 @@ class FillBoxViewController: BaseViewController {
         
         parentGoalTableView.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide)
-            make.left.right.equalToSuperview().inset(24)
+            make.left.right.equalToSuperview().inset(20)
             make.bottom.equalToSuperview().inset(16)
         }
         addGoalButton.snp.makeConstraints { make in
@@ -87,7 +87,7 @@ extension FillBoxViewController: UITableViewDataSource, UITableViewDelegate {
     }
     // 헤더뷰 높이 설정
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        80 + 16
+        80 + 8
     }
     // 셀 높이 설정
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {


### PR DESCRIPTION
## 상세 내용
- #13 Reopen
- 디자인 변경에 따라 오른쪽 하단의 플로팅 버튼의 배경색, 그림자 색 변경
- 테이블뷰 셀의 양옆이 슈퍼뷰와 같아 양옆의 그림자가 잘리길래 레이아웃 수정 -> 양옆 패딩을 주어 그림자가 질 공간을 확보함

## 스크린샷

### 1. 수정 전

<img width="414" alt="스크린샷 2023-08-11 오전 8 40 27" src="https://github.com/dnd-side-project/dnd-9th-1-ios/assets/87434861/aeb603cd-dc0e-42e3-b98b-027edc49119a">  

### 2. 수정 후

<img width="426" alt="스크린샷 2023-08-14 오후 11 40 41" src="https://github.com/dnd-side-project/dnd-9th-1-ios/assets/87434861/20ec900e-454b-4d17-9cef-aba1771ccaec">

## 셀프 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩 컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 오른쪽의 Development에서 이슈와 연결하였는가?
