### PR TITLE
[#35] 공통 뷰모델 프로토콜 정의

### DIFF
--- a/Milestone/Milestone.xcodeproj/project.pbxproj
+++ b/Milestone/Milestone.xcodeproj/project.pbxproj
@@ -162,6 +162,8 @@
 		C90DC9862A88F0B100241B7C /* UITextField+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90DC9852A88F0B100241B7C /* UITextField+.swift */; };
 		C90DC9882A891A8500241B7C /* OnboardingViewControllerLast.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90DC9872A891A8500241B7C /* OnboardingViewControllerLast.swift */; };
 		C90DC98A2A8922D300241B7C /* NSMutableAttributedString+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90DC9892A8922D300241B7C /* NSMutableAttributedString+.swift */; };
+		C9B2CDD62A8A77F1006289A8 /* CompletionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B2CDD52A8A77F1006289A8 /* CompletionViewModel.swift */; };
+		C9B2CDD82A8A7B26006289A8 /* ViewModelBindableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B2CDD72A8A7B26006289A8 /* ViewModelBindableType.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -247,6 +249,8 @@
 		C90DC9852A88F0B100241B7C /* UITextField+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+.swift"; sourceTree = "<group>"; };
 		C90DC9872A891A8500241B7C /* OnboardingViewControllerLast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewControllerLast.swift; sourceTree = "<group>"; };
 		C90DC9892A8922D300241B7C /* NSMutableAttributedString+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMutableAttributedString+.swift"; sourceTree = "<group>"; };
+		C9B2CDD52A8A77F1006289A8 /* CompletionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionViewModel.swift; sourceTree = "<group>"; };
+		C9B2CDD72A8A7B26006289A8 /* ViewModelBindableType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelBindableType.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -518,6 +522,7 @@
 		A2D304C52A856AF400A5BA92 /* CompletionBox */ = {
 			isa = PBXGroup;
 			children = (
+				C9B2CDD42A8A77D7006289A8 /* ViewModel */,
 				A2D304C72A856B4F00A5BA92 /* View */,
 			);
 			path = CompletionBox;
@@ -586,6 +591,7 @@
 				A2FA59182A7FD2CF006ACA2E /* BaseViewController.swift */,
 				A2FA591C2A7FD2DD006ACA2E /* BaseCollectionViewCell.swift */,
 				A2FA59202A7FD2EC006ACA2E /* BaseTableViewCell.swift */,
+				C9B2CDD72A8A7B26006289A8 /* ViewModelBindableType.swift */,
 			);
 			path = Base;
 			sourceTree = "<group>";
@@ -615,6 +621,14 @@
 				A2FA59302A7FD6D3006ACA2E /* View */,
 			);
 			path = Onboarding;
+			sourceTree = "<group>";
+		};
+		C9B2CDD42A8A77D7006289A8 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				C9B2CDD52A8A77F1006289A8 /* CompletionViewModel.swift */,
+			);
+			path = ViewModel;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -845,6 +859,7 @@
 				A2FA59212A7FD2EC006ACA2E /* BaseTableViewCell.swift in Sources */,
 				A2FA58E12A7F7A4A006ACA2E /* APIService.swift in Sources */,
 				A2FA59142A7FCFC8006ACA2E /* Data+.swift in Sources */,
+				C9B2CDD82A8A7B26006289A8 /* ViewModelBindableType.swift in Sources */,
 				A2FA591D2A7FD2DD006ACA2E /* BaseCollectionViewCell.swift in Sources */,
 				A2B20D902A7ED14C001ED73C /* ImageLiteral.swift in Sources */,
 				A2FA59292A7FD3BA006ACA2E /* UITableView+.swift in Sources */,
@@ -856,6 +871,7 @@
 				A2D304C12A854EDE00A5BA92 /* MainSegmentedControl.swift in Sources */,
 				A2B20D9A2A7ED40D001ED73C /* Logger.swift in Sources */,
 				A2B20D592A7E4E5C001ED73C /* UIFont+.swift in Sources */,
+				C9B2CDD62A8A77F1006289A8 /* CompletionViewModel.swift in Sources */,
 				A2B20D942A7ED174001ED73C /* UIImage+.swift in Sources */,
 				A28EDA152A8791F7001A021A /* DetailGoalCollectionViewCell.swift in Sources */,
 				C90DC9822A88854C00241B7C /* OnboardingViewController.swift in Sources */,

--- a/Milestone/Milestone/Global/Base/ViewModelBindableType.swift
+++ b/Milestone/Milestone/Global/Base/ViewModelBindableType.swift
@@ -1,0 +1,24 @@
+//
+//  BaseViewModel.swift
+//  Milestone
+//
+//  Created by 박경준 on 2023/08/15.
+//
+
+import UIKit
+
+protocol ViewModelBindableType {
+    associatedtype ViewModelType
+    
+    var viewModel: ViewModelType! { get set }
+    func bindViewModel()
+}
+
+extension ViewModelBindableType where Self: UIViewController {
+    mutating func bind(viewModel: Self.ViewModelType) {
+        self.viewModel = viewModel
+        
+        loadViewIfNeeded()
+        bindViewModel()
+    }
+}

--- a/Milestone/Milestone/Screens/CompletionBox/View/CompletionBoxViewController.swift
+++ b/Milestone/Milestone/Screens/CompletionBox/View/CompletionBoxViewController.swift
@@ -10,8 +10,9 @@ import UIKit
 import SnapKit
 import Then
 
-class CompletionBoxViewController: BaseViewController {
+class CompletionBoxViewController: BaseViewController, ViewModelBindableType {
     
+    // MARK: subviews
     private let emptyImageView = UIImageView()
         .then {
             $0.image = ImageLiteral.imgcompletionEmpty
@@ -28,8 +29,22 @@ class CompletionBoxViewController: BaseViewController {
             $0.textAlignment = .center
         }
     
+    private let alertBox = UIView()
+        .then {
+            $0.isHidden = true
+            $0.layer.cornerRadius = 20
+            $0.backgroundColor = .white
+        }
+    
+    // MARK: Properties
+    var coordinator: CompletionViewFlow?
+    
+    var viewModel: CompletionViewModel!
+    
+    // MARK: functions
+    
     override func render() {
-        view.addSubViews([emptyImageView, label])
+        view.addSubViews([emptyImageView, label, alertBox])
         
         emptyImageView.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(100)
@@ -40,9 +55,35 @@ class CompletionBoxViewController: BaseViewController {
             make.top.equalTo(emptyImageView.snp.bottom).offset(24)
             make.centerX.equalTo(view.snp.centerX)
         }
+        
+        alertBox.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide.snp.bottom).offset(16)
+            make.leading.equalTo(view.snp.leading).offset(24)
+            make.trailing.equalTo(view.snp.trailing).offset(-24)
+            make.height.equalTo(60)
+        }
     }
     
     override func configUI() {
         view.backgroundColor = .gray01
+        
+        bindViewModel()
+    }
+    
+    func bindViewModel() {
+        
+        viewModel.goalList
+            .subscribe(onNext: { [weak self] elem in
+                if(elem.isEmpty) {
+                    self?.alertBox.isHidden = true
+                    self?.emptyImageView.isHidden = false
+                    self?.label.isHidden = false
+                } else {
+                    self?.alertBox.isHidden = false
+                    self?.emptyImageView.isHidden = true
+                    self?.label.isHidden = true
+                }
+            })
+            .disposed(by: disposeBag)
     }
 }

--- a/Milestone/Milestone/Screens/CompletionBox/ViewModel/CompletionViewModel.swift
+++ b/Milestone/Milestone/Screens/CompletionBox/ViewModel/CompletionViewModel.swift
@@ -1,0 +1,19 @@
+//
+//  CompletionViewModel.swift
+//  Milestone
+//
+//  Created by 박경준 on 2023/08/14.
+//
+
+import Foundation
+import RxSwift
+
+struct Goal {
+    let title: String
+    let startDate: Date
+    let endDate: Date
+}
+
+class CompletionViewModel {
+    var goalList = Observable.just([Goal(title: "포토샵 자격증 따기", startDate: Date(), endDate: Date().addingTimeInterval(100)), Goal(title: "자격증 포토샵 따기", startDate: Date().addingTimeInterval(100), endDate: Date().addingTimeInterval(200)), Goal(title: "스위프트 마스터하기", startDate: Date().addingTimeInterval(300), endDate: Date().addingTimeInterval(500))])
+}

--- a/Milestone/Milestone/Screens/Main/View/MainViewController.swift
+++ b/Milestone/Milestone/Screens/Main/View/MainViewController.swift
@@ -29,7 +29,7 @@ class MainViewController: BaseViewController {
     
     private let storageBoxVC = StorageBoxViewController()
     private let fillBoxVC = FillBoxViewController()
-    private let completionVC = CompletionBoxViewController()
+    private var completionVC = CompletionBoxViewController()
     var viewControllers: [UIViewController] { [self.storageBoxVC, self.fillBoxVC, self.completionVC] }
     
     private lazy var pageViewController = UIPageViewController(transitionStyle: .scroll, navigationOrientation: .horizontal, options: nil)
@@ -60,6 +60,7 @@ class MainViewController: BaseViewController {
         super.viewDidLoad()
         
         changeCurrentPage(control: self.segmentedControl)
+        bindingModels()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -109,6 +110,11 @@ class MainViewController: BaseViewController {
             ],
             for: .selected
         )
+    }
+    
+    /// 세 개의 섹션들에 대해 뷰모델 바인딩
+    func bindingModels() {
+        completionVC.bind(viewModel: CompletionViewModel())
     }
     
     // MARK: - @objc Functions


### PR DESCRIPTION
## 상세 내용
- #35 
1. 뷰 컨트롤러에서 뷰모델을 바인딩하기 위한 프로토콜을 정의했습니다.
2. 뷰모델을 바인딩하는 뷰에서는 해당 프로토콜을 반드시 채택해야합니다.
3. 프로토콜 채택 후 뷰컨트롤러 내에서 구현하는 함수는 `bindViewModel()` 입니다. RxSwift / RxCocoa를 활용한 바인딩 로직들이 모두 해당 함수에 들어가게 됩니다.
4. 프로토콜 내에 `mutating func bind(viewModel: ViewModelType)`이라는 확장 함수가 있는데, 이는 코디네이터에서 다른 뷰모델을 가진 뷰로 이동할때에 뷰컨에 뷰모델을 연결해주기 위함입니다.

예를 들어, [다음 링크](https://github.com/dnd-side-project/dnd-9th-1-ios/blob/ecfd867d5f617696c9c060017a304820f2b20f2b/Milestone/Milestone/Screens/Main/View/MainViewController.swift#L116-L118C6)를 보시면 메인 뷰컨이 푸시되면 `bindingModels`라는 메서드가 호출되는데 이때 완료함, 보관함, 채움함 뷰 각각에 대해 뷰모델 바인딩을 진행합니다.

이때 진행하는 뷰모델 바인딩 함수가 `ViewModelBindableType` 프로토콜의 mutating 함수입니다. (where ViewModelType: UIViewController 구문 참조)

<br/>

## 기타

<br/>

## 셀프 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩 컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 오른쪽의 Development에서 이슈와 연결하였는가?
