### PR TITLE
[#48] 자유롭게 쓰기 뷰 제작 / 마일이 질문 받기 로직 개선

### DIFF
--- a/Milestone/Milestone/Global/Resource/Assets.xcassets/beforeSelected1.imageset/Contents.json
+++ b/Milestone/Milestone/Global/Resource/Assets.xcassets/beforeSelected1.imageset/Contents.json
@@ -1,7 +1,7 @@
 {
   "images" : [
     {
-      "filename" : "beforeSelected5.svg",
+      "filename" : "beforeSelected1.svg",
       "idiom" : "universal"
     }
   ],

--- a/Milestone/Milestone/Global/Resource/Assets.xcassets/beforeSelected1.imageset/beforeSelected1.svg
+++ b/Milestone/Milestone/Global/Resource/Assets.xcassets/beforeSelected1.imageset/beforeSelected1.svg
@@ -1,5 +1,5 @@
 <svg width="52" height="52" viewBox="0 0 52 52" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<rect opacity="0.6" width="52" height="52" fill="url(#pattern0)"/>
+<rect opacity="0.4" width="52" height="52" fill="url(#pattern0)"/>
 <defs>
 <pattern id="pattern0" patternContentUnits="objectBoundingBox" width="1" height="1">
 <use xlink:href="#image0_724_2875" transform="scale(0.000846024)"/>

--- a/Milestone/Milestone/Global/Resource/Assets.xcassets/beforeSelected2.imageset/Contents.json
+++ b/Milestone/Milestone/Global/Resource/Assets.xcassets/beforeSelected2.imageset/Contents.json
@@ -1,7 +1,7 @@
 {
   "images" : [
     {
-      "filename" : "beforeSelected4.svg",
+      "filename" : "beforeSelected2.svg",
       "idiom" : "universal"
     }
   ],

--- a/Milestone/Milestone/Global/Resource/Assets.xcassets/beforeSelected2.imageset/beforeSelected2.svg
+++ b/Milestone/Milestone/Global/Resource/Assets.xcassets/beforeSelected2.imageset/beforeSelected2.svg
@@ -1,5 +1,5 @@
 <svg width="52" height="52" viewBox="0 0 52 52" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<rect opacity="0.6" width="52" height="52" fill="url(#pattern0)"/>
+<rect opacity="0.4" width="52" height="52" fill="url(#pattern0)"/>
 <defs>
 <pattern id="pattern0" patternContentUnits="objectBoundingBox" width="1" height="1">
 <use xlink:href="#image0_724_2874" transform="scale(0.000846024)"/>

--- a/Milestone/Milestone/Global/Resource/Assets.xcassets/beforeSelected3.imageset/beforeSelected3.svg
+++ b/Milestone/Milestone/Global/Resource/Assets.xcassets/beforeSelected3.imageset/beforeSelected3.svg
@@ -1,5 +1,5 @@
 <svg width="52" height="52" viewBox="0 0 52 52" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<rect opacity="0.6" width="52" height="52" fill="url(#pattern0)"/>
+<rect opacity="0.4" width="52" height="52" fill="url(#pattern0)"/>
 <defs>
 <pattern id="pattern0" patternContentUnits="objectBoundingBox" width="1" height="1">
 <use xlink:href="#image0_724_2873" transform="scale(0.000846024)"/>

--- a/Milestone/Milestone/Global/Resource/Assets.xcassets/beforeSelected4.imageset/Contents.json
+++ b/Milestone/Milestone/Global/Resource/Assets.xcassets/beforeSelected4.imageset/Contents.json
@@ -1,7 +1,7 @@
 {
   "images" : [
     {
-      "filename" : "beforeSelected2.svg",
+      "filename" : "beforeSelected4.svg",
       "idiom" : "universal"
     }
   ],

--- a/Milestone/Milestone/Global/Resource/Assets.xcassets/beforeSelected4.imageset/beforeSelected4.svg
+++ b/Milestone/Milestone/Global/Resource/Assets.xcassets/beforeSelected4.imageset/beforeSelected4.svg
@@ -1,5 +1,5 @@
 <svg width="52" height="52" viewBox="0 0 52 52" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<rect opacity="0.6" width="52" height="52" fill="url(#pattern0)"/>
+<rect opacity="0.4" width="52" height="52" fill="url(#pattern0)"/>
 <defs>
 <pattern id="pattern0" patternContentUnits="objectBoundingBox" width="1" height="1">
 <use xlink:href="#image0_724_2872" transform="scale(0.000846024)"/>

--- a/Milestone/Milestone/Global/Resource/Assets.xcassets/beforeSelected5.imageset/Contents.json
+++ b/Milestone/Milestone/Global/Resource/Assets.xcassets/beforeSelected5.imageset/Contents.json
@@ -1,7 +1,7 @@
 {
   "images" : [
     {
-      "filename" : "beforeSelected1.svg",
+      "filename" : "beforeSelected5.svg",
       "idiom" : "universal"
     }
   ],

--- a/Milestone/Milestone/Global/Resource/Assets.xcassets/beforeSelected5.imageset/beforeSelected5.svg
+++ b/Milestone/Milestone/Global/Resource/Assets.xcassets/beforeSelected5.imageset/beforeSelected5.svg
@@ -1,5 +1,5 @@
 <svg width="52" height="52" viewBox="0 0 52 52" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<rect opacity="0.6" width="52" height="52" fill="url(#pattern0)"/>
+<rect opacity="0.4" width="52" height="52" fill="url(#pattern0)"/>
 <defs>
 <pattern id="pattern0" patternContentUnits="objectBoundingBox" width="1" height="1">
 <use xlink:href="#image0_724_2871" transform="scale(0.000846024)"/>

--- a/Milestone/Milestone/Screens/CompletionBox/View/CompletionBoxViewController.swift
+++ b/Milestone/Milestone/Screens/CompletionBox/View/CompletionBoxViewController.swift
@@ -61,8 +61,8 @@ class CompletionBoxViewController: BaseViewController, ViewModelBindableType {
         }
     
     var tapDisposable: [Disposable] = []
-    var cellHideDisposable: Disposable!
-    var nsAttributedStringDisposable: Disposable!
+    var cellHideDisposable: Disposable?
+    var nsAttributedStringDisposable: Disposable?
     
     // MARK: Properties
     
@@ -121,8 +121,8 @@ class CompletionBoxViewController: BaseViewController, ViewModelBindableType {
         }
         tapDisposable = []
         
-        cellHideDisposable.dispose()
-        nsAttributedStringDisposable.dispose()
+        cellHideDisposable?.dispose()
+        nsAttributedStringDisposable?.dispose()
     }
     
     // MARK: functions

--- a/Milestone/Milestone/Screens/CompletionBox/View/CompletionReviewViewController.swift
+++ b/Milestone/Milestone/Screens/CompletionBox/View/CompletionReviewViewController.swift
@@ -14,6 +14,9 @@ class CompletionReviewViewController: BaseViewController, ViewModelBindableType 
     // MARK: Subviews
     
     let titleBox = UIView()
+        .then {
+            $0.backgroundColor = .systemBackground
+        }
 
     let titleLabel = UILabel()
         .then {
@@ -90,13 +93,13 @@ class CompletionReviewViewController: BaseViewController, ViewModelBindableType 
         
         titleBox.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide.snp.top)
-            make.leading.equalTo(view.snp.leading).offset(24)
-            make.trailing.equalTo(view.snp.trailing).offset(-24)
+            make.leading.equalTo(view.snp.leading)
+            make.trailing.equalTo(view.snp.trailing)
             make.height.equalTo(90)
         }
         
         titleLabel.snp.makeConstraints { make in
-            make.leading.equalTo(titleBox.snp.leading)
+            make.leading.equalTo(titleBox.snp.leading).offset(24)
             make.top.equalTo(titleBox.snp.top).offset(16)
         }
         
@@ -142,6 +145,17 @@ class CompletionReviewViewController: BaseViewController, ViewModelBindableType 
         singleTapGestureRecognizer.isEnabled = true
         singleTapGestureRecognizer.cancelsTouchesInView = false
         pageViewController.view.addGestureRecognizer(singleTapGestureRecognizer)
+        
+        scrollView.rx.didScroll
+            .asDriver()
+            .drive(onNext: { [unowned self] _ in
+                if self.scrollView.contentOffset.y <= 0 {
+                    self.titleBox.makeShadow(alpha: 0, x: 0, y: 0, blur: 0, spread: 0)
+                } else {
+                    self.titleBox.makeShadow(color: .init(hex: "#464646", alpha: 0.1), alpha: 1, x: 0, y: 10, blur: 10, spread: 0)
+                }
+            })
+            .disposed(by: disposeBag)
     }
     
     func bindViewModel() {

--- a/Milestone/Milestone/Screens/CompletionBox/View/CompletionReviewWithGuideViewController.swift
+++ b/Milestone/Milestone/Screens/CompletionBox/View/CompletionReviewWithGuideViewController.swift
@@ -74,6 +74,8 @@ class CompletionReviewWithGuideViewController: BaseViewController {
         case highest = "완전 만족해요"
     }
     
+    private var fillSelected = false
+    
     // MARK: Life Cycles
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
@@ -95,28 +97,28 @@ class CompletionReviewWithGuideViewController: BaseViewController {
             make.leading.equalTo(view.snp.leading)
             make.trailing.equalTo(view.snp.trailing)
             make.top.equalTo(view.snp.top)
-            make.height.equalTo(244)
+            make.height.equalTo(260)
         }
         
         secondQuestionView.snp.makeConstraints { make in
             make.leading.equalTo(view.snp.leading)
             make.trailing.equalTo(view.snp.trailing)
             make.top.equalTo(firstQuestionView.snp.bottom).offset(24)
-            make.height.equalTo(244)
+            make.height.equalTo(260)
         }
         
         thirdQuestionView.snp.makeConstraints { make in
             make.leading.equalTo(view.snp.leading)
             make.trailing.equalTo(view.snp.trailing)
             make.top.equalTo(secondQuestionView.snp.bottom).offset(24)
-            make.height.equalTo(244)
+            make.height.equalTo(260)
         }
         
         fourthQuestionView.snp.makeConstraints { make in
             make.leading.equalTo(view.snp.leading)
             make.trailing.equalTo(view.snp.trailing)
             make.top.equalTo(thirdQuestionView.snp.bottom).offset(24)
-            make.height.equalTo(244)
+            make.height.equalTo(260)
         }
         
         fillLabel.snp.makeConstraints { make in
@@ -153,6 +155,7 @@ class CompletionReviewWithGuideViewController: BaseViewController {
         setAttributedIndexLabel()
         setPointViews()
         selectPointView()
+        validateInput()
     }
     
     func setAttributedIndexLabel() {
@@ -204,8 +207,10 @@ class CompletionReviewWithGuideViewController: BaseViewController {
     func selectPointView() {
         lowestPointView.pointButton.rx.tap
             .subscribe(onNext: { [unowned self] in
+                self.fillSelected = true
+                
                 self.lowestPointView.pointButton.setBackgroundImage(ImageLiteral.imgAfterSelected1, for: .normal)
-                self.lowestPointView.pointLabel.textColor = .black
+                self.lowestPointView.pointLabel.textColor = .primary
                 
                 self.lowerPointView.pointButton.setBackgroundImage(ImageLiteral.imgBeforeSelected2, for: .normal)
                 self.lowerPointView.pointLabel.textColor = .gray02
@@ -223,11 +228,13 @@ class CompletionReviewWithGuideViewController: BaseViewController {
         
         lowerPointView.pointButton.rx.tap
             .subscribe(onNext: {
+                self.fillSelected = true
+                
                 self.lowestPointView.pointButton.setBackgroundImage(ImageLiteral.imgBeforeSelected1, for: .normal)
                 self.lowestPointView.pointLabel.textColor = .gray02
                 
                 self.lowerPointView.pointButton.setBackgroundImage(ImageLiteral.imgAfterSelected2, for: .normal)
-                self.lowerPointView.pointLabel.textColor = .black
+                self.lowerPointView.pointLabel.textColor = .primary
                 
                 self.middlePointView.pointButton.setBackgroundImage(ImageLiteral.imgBeforeSelected3, for: .normal)
                 self.middlePointView.pointLabel.textColor = .gray02
@@ -243,6 +250,8 @@ class CompletionReviewWithGuideViewController: BaseViewController {
         
         middlePointView.pointButton.rx.tap
             .subscribe(onNext: {
+                self.fillSelected = true
+                
                 self.lowestPointView.pointButton.setBackgroundImage(ImageLiteral.imgBeforeSelected1, for: .normal)
                 self.lowestPointView.pointLabel.textColor = .gray02
                 
@@ -250,7 +259,7 @@ class CompletionReviewWithGuideViewController: BaseViewController {
                 self.lowerPointView.pointLabel.textColor = .gray02
                 
                 self.middlePointView.pointButton.setBackgroundImage(ImageLiteral.imgAfterSelected3, for: .normal)
-                self.middlePointView.pointLabel.textColor = .black
+                self.middlePointView.pointLabel.textColor = .primary
                 
                 self.higherPointView.pointButton.setBackgroundImage(ImageLiteral.imgBeforeSelected4, for: .normal)
                 self.higherPointView.pointLabel.textColor = .gray02
@@ -263,6 +272,8 @@ class CompletionReviewWithGuideViewController: BaseViewController {
         
         higherPointView.pointButton.rx.tap
             .subscribe(onNext: {
+                self.fillSelected = true
+                
                 self.lowestPointView.pointButton.setBackgroundImage(ImageLiteral.imgBeforeSelected1, for: .normal)
                 self.lowestPointView.pointLabel.textColor = .gray02
                 
@@ -273,7 +284,7 @@ class CompletionReviewWithGuideViewController: BaseViewController {
                 self.middlePointView.pointLabel.textColor = .gray02
                 
                 self.higherPointView.pointButton.setBackgroundImage(ImageLiteral.imgAfterSelected4, for: .normal)
-                self.higherPointView.pointLabel.textColor = .black
+                self.higherPointView.pointLabel.textColor = .primary
                 
                 self.highestPointView.pointButton.setBackgroundImage(ImageLiteral.imgBeforeSelected5, for: .normal)
                 self.highestPointView.pointLabel.textColor = .gray02
@@ -283,6 +294,8 @@ class CompletionReviewWithGuideViewController: BaseViewController {
         
         highestPointView.pointButton.rx.tap
             .subscribe(onNext: {
+                self.fillSelected = true
+                
                 self.lowestPointView.pointButton.setBackgroundImage(ImageLiteral.imgBeforeSelected1, for: .normal)
                 self.lowestPointView.pointLabel.textColor = .gray02
                 
@@ -296,8 +309,46 @@ class CompletionReviewWithGuideViewController: BaseViewController {
                 self.higherPointView.pointLabel.textColor = .gray02
                 
                 self.highestPointView.pointButton.setBackgroundImage(ImageLiteral.imgAfterSelected5, for: .normal)
-                self.highestPointView.pointLabel.textColor = .black
+                self.highestPointView.pointLabel.textColor = .primary
             })
             .disposed(by: disposeBag)
+    }
+    
+    /// 입력 유효성 검사
+    func validateInput() {
+        let firstObservable = firstQuestionView.textView.rx.text
+            .compactMap { $0 }
+            .map { $0 != "내용을 입력해주세요!" ? $0.count : 0}
+        
+        let secondObservable = secondQuestionView.textView.rx.text
+            .compactMap { $0 }
+            .map { $0 != "내용을 입력해주세요!" ? $0.count : 0}
+        
+        let thirdObservable = thirdQuestionView.textView.rx.text
+            .compactMap { $0 }
+            .map { $0 != "내용을 입력해주세요!" ? $0.count : 0}
+        
+        let fourthObservable = fourthQuestionView.textView.rx.text
+            .compactMap { $0 }
+            .map { $0 != "내용을 입력해주세요!" ? $0.count : 0}
+        
+        Observable.combineLatest(firstObservable, secondObservable, thirdObservable, fourthObservable) { first, second, third, fourth -> Bool in
+            if first > 0 && second > 0 && third > 0 && fourth > 0 {
+                return true
+            } else {
+                return false
+            }
+        }
+        .subscribe(onNext: { [unowned self] in
+            if self.fillSelected && $0 {
+                self.registerButton.backgroundColor = .primary
+                self.registerButton.isEnabled = true
+            } else {
+                self.registerButton.backgroundColor = .init(hex: "#ADBED6")
+                self.registerButton.isEnabled = false
+            }
+        })
+        .disposed(by: disposeBag)
+            
     }
 }

--- a/Milestone/Milestone/Screens/CompletionBox/View/CompletionReviewWithGuideViewController.swift
+++ b/Milestone/Milestone/Screens/CompletionBox/View/CompletionReviewWithGuideViewController.swift
@@ -74,7 +74,7 @@ class CompletionReviewWithGuideViewController: BaseViewController {
         case highest = "완전 만족해요"
     }
     
-    private var fillSelected = false
+    private var fillSelected = PublishSubject<Bool>()
     
     // MARK: Life Cycles
     override func viewDidAppear(_ animated: Bool) {
@@ -207,7 +207,7 @@ class CompletionReviewWithGuideViewController: BaseViewController {
     func selectPointView() {
         lowestPointView.pointButton.rx.tap
             .subscribe(onNext: { [unowned self] in
-                self.fillSelected = true
+                self.fillSelected.onNext(true)
                 
                 self.lowestPointView.pointButton.setBackgroundImage(ImageLiteral.imgAfterSelected1, for: .normal)
                 self.lowestPointView.pointLabel.textColor = .primary
@@ -228,7 +228,7 @@ class CompletionReviewWithGuideViewController: BaseViewController {
         
         lowerPointView.pointButton.rx.tap
             .subscribe(onNext: {
-                self.fillSelected = true
+                self.fillSelected.onNext(true)
                 
                 self.lowestPointView.pointButton.setBackgroundImage(ImageLiteral.imgBeforeSelected1, for: .normal)
                 self.lowestPointView.pointLabel.textColor = .gray02
@@ -250,7 +250,7 @@ class CompletionReviewWithGuideViewController: BaseViewController {
         
         middlePointView.pointButton.rx.tap
             .subscribe(onNext: {
-                self.fillSelected = true
+                self.fillSelected.onNext(true)
                 
                 self.lowestPointView.pointButton.setBackgroundImage(ImageLiteral.imgBeforeSelected1, for: .normal)
                 self.lowestPointView.pointLabel.textColor = .gray02
@@ -272,7 +272,7 @@ class CompletionReviewWithGuideViewController: BaseViewController {
         
         higherPointView.pointButton.rx.tap
             .subscribe(onNext: {
-                self.fillSelected = true
+                self.fillSelected.onNext(true)
                 
                 self.lowestPointView.pointButton.setBackgroundImage(ImageLiteral.imgBeforeSelected1, for: .normal)
                 self.lowestPointView.pointLabel.textColor = .gray02
@@ -294,7 +294,7 @@ class CompletionReviewWithGuideViewController: BaseViewController {
         
         highestPointView.pointButton.rx.tap
             .subscribe(onNext: {
-                self.fillSelected = true
+                self.fillSelected.onNext(true)
                 
                 self.lowestPointView.pointButton.setBackgroundImage(ImageLiteral.imgBeforeSelected1, for: .normal)
                 self.lowestPointView.pointLabel.textColor = .gray02
@@ -332,15 +332,15 @@ class CompletionReviewWithGuideViewController: BaseViewController {
             .compactMap { $0 }
             .map { $0 != "내용을 입력해주세요!" ? $0.count : 0}
         
-        Observable.combineLatest(firstObservable, secondObservable, thirdObservable, fourthObservable) { first, second, third, fourth -> Bool in
-            if first > 0 && second > 0 && third > 0 && fourth > 0 {
+        Observable.combineLatest(firstObservable, secondObservable, thirdObservable, fourthObservable, fillSelected) { first, second, third, fourth, fill -> Bool in
+            if first > 0 && second > 0 && third > 0 && fourth > 0 && fill {
                 return true
             } else {
                 return false
             }
         }
         .subscribe(onNext: { [unowned self] in
-            if self.fillSelected && $0 {
+            if $0 {
                 self.registerButton.backgroundColor = .primary
                 self.registerButton.isEnabled = true
             } else {

--- a/Milestone/Milestone/Screens/CompletionBox/View/CompletionReviewWithoutGuideViewController.swift
+++ b/Milestone/Milestone/Screens/CompletionBox/View/CompletionReviewWithoutGuideViewController.swift
@@ -7,12 +7,335 @@
 
 import UIKit
 
-class CompletionReviewWithoutGuideViewController: UIViewController {
+import RxCocoa
+import RxSwift
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
-        view.backgroundColor = .green
+class CompletionReviewWithoutGuideViewController: BaseViewController {
+    
+    // MARK: Subviews
+    let textViewWrapper = UIView()
+        .then {
+            $0.layer.cornerRadius = 20
+            $0.backgroundColor = .gray01
+        }
+    
+    let textView = UITextView()
+        .then {
+            $0.textContainerInset = UIEdgeInsets(top: 24, left: 0, bottom: 0, right: 0)
+            $0.text = "자유롭게 회고를 작성해보세요!"
+            $0.backgroundColor = .gray01
+            
+            let style = NSMutableParagraphStyle()
+            style.lineHeightMultiple = 1.3
+            let attributes = [NSMutableAttributedString.Key.paragraphStyle: style, NSMutableAttributedString.Key.font: UIFont.pretendard(.regular, ofSize: 14), NSMutableAttributedString.Key.foregroundColor: UIColor.gray02]
+            $0.attributedText = NSAttributedString(string: $0.text, attributes: attributes)
+        }
+    
+    let textCountLabel = UILabel()
+        .then {
+            $0.textAlignment = .right
+            $0.backgroundColor = .gray01
+            $0.font = .pretendard(.regular, ofSize: 10)
+        }
+    
+    let fillLabel = UILabel()
+        .then {
+            $0.font = UIFont.pretendard(.semibold, ofSize: 16)
+            $0.text = "마음 채움도"
+        }
+    
+    let fillInformationLabel = UILabel()
+        .then {
+            $0.textColor = .gray03
+            $0.font = UIFont.pretendard(.regular, ofSize: 12)
+            $0.text = "이 목표를 이뤄낸 것이 얼마나 도움됐나요?"
+        }
+    
+    let lowestPointView = PointView()
+    let lowerPointView = PointView()
+    let middlePointView = PointView()
+    let higherPointView = PointView()
+    let highestPointView = PointView()
+    
+    private lazy var fillPointStackView = UIStackView(arrangedSubviews: [self.lowestPointView, self.lowerPointView, self.middlePointView, self.higherPointView, self.highestPointView])
+        .then {
+            $0.distribution = .equalSpacing
+            $0.spacing = 6
+            $0.axis = .horizontal
+        }
+    
+    let registerButton = UIButton(type: .system)
+        .then {
+            $0.titleLabel?.font = .pretendard(.semibold, ofSize: 16)
+            $0.layer.cornerRadius = 20
+            $0.isEnabled = false
+            $0.setTitleColor(.white, for: .normal)
+            $0.setTitle("회고 작성 완료", for: .normal)
+            
+            $0.setTitleColor(.gray01, for: .disabled)
+            $0.setTitle("회고 작성 완료", for: .disabled)
+            $0.backgroundColor = UIColor(hex: "#ADBED6")
+        }
+    
+    // MARK: Properties
+    let heightSubject = PublishSubject<Int>()
+    
+    enum PointText: String {
+        case lowest = "별로예요"
+        case lower = "아쉬워요"
+        case middle = "그저 그랬어요"
+        case higher = "만족해요"
+        case highest = "완전 만족해요"
     }
-
+    
+    var fillSelected = PublishSubject<Bool>()
+    
+    // MARK: Life Cycles
+    
+    // MARK: Functions
+    override func render() {
+        view.addSubViews([textViewWrapper, textView, textCountLabel, fillLabel, fillInformationLabel, fillPointStackView, registerButton])
+        
+        textViewWrapper.snp.makeConstraints { make in
+            make.top.equalTo(view.snp.top)
+            make.leading.equalTo(view.snp.leading).offset(24)
+            make.trailing.equalTo(view.snp.trailing).offset(-24)
+            make.height.equalTo(320)
+        }
+        
+        textView.snp.makeConstraints { make in
+            make.top.equalTo(textViewWrapper.snp.top)
+            make.leading.equalTo(textViewWrapper.snp.leading).offset(24)
+            make.trailing.equalTo(textViewWrapper.snp.trailing).offset(-24)
+            make.bottom.equalTo(textViewWrapper.snp.bottom).offset(-48)
+        }
+        
+        textCountLabel.snp.makeConstraints { make in
+            make.trailing.equalTo(textViewWrapper.snp.trailing).offset(-24)
+            make.bottom.equalTo(textViewWrapper.snp.bottom).offset(-24)
+        }
+        
+        fillLabel.snp.makeConstraints { make in
+            make.top.equalTo(textViewWrapper.snp.bottom).offset(24)
+            make.leading.equalTo(view.snp.leading).offset(24)
+        }
+        
+        fillInformationLabel.snp.makeConstraints { make in
+            make.top.equalTo(fillLabel.snp.bottom).offset(4)
+            make.leading.equalTo(fillLabel.snp.leading)
+        }
+        
+        fillPointStackView.snp.makeConstraints { make in
+            make.leading.equalTo(view.snp.leading).offset(24)
+            make.trailing.equalTo(view.snp.trailing).offset(-24)
+            make.top.equalTo(fillInformationLabel.snp.bottom).offset(24)
+            make.height.equalTo(72)
+        }
+        
+        registerButton.snp.makeConstraints { make in
+            make.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).offset(-16)
+            make.leading.equalTo(view.snp.leading).offset(24)
+            make.trailing.equalTo(view.snp.trailing).offset(-24)
+            make.height.equalTo(54)
+        }
+    }
+    
+    override func configUI() {
+        selectPointView()
+        setPointViews()
+        validateInput()
+        
+        textView.rx.didBeginEditing
+            .subscribe(onNext: { [unowned self] in
+                if self.textView.text == "자유롭게 회고를 작성해보세요!" {
+                    self.textView.text = ""
+                }
+                self.textView.textColor = .black
+            })
+            .disposed(by: disposeBag)
+        
+        textView.rx.didEndEditing
+            .subscribe(onNext: { [unowned self] in
+                if self.textView.text.isEmpty {
+                    self.textView.text = "자유롭게 회고를 작성해보세요!"
+                    self.textView.textColor = .gray02
+                }
+            })
+            .disposed(by: disposeBag)
+        
+        textView.rx.text
+            .compactMap { $0 }
+            .map { "\($0 == "자유롭게 회고를 작성해보세요!" ? 0 : $0.count)/1000" }
+            .bind(to: textCountLabel.rx.text)
+            .disposed(by: disposeBag)
+        
+        textView.rx.text
+            .compactMap { $0 }
+            .scan("") { previous, new in
+                return new.count <= 1000 ? new : previous
+            }
+            .bind(to: textView.rx.text)
+            .disposed(by: disposeBag)
+        
+    }
+    
+    func setPointViews() {
+        lowestPointView.image
+            .onNext(ImageLiteral.imgBeforeSelected1)
+        lowestPointView.pointText
+            .onNext(PointText.lowest.rawValue)
+        
+        lowerPointView.image
+            .onNext(ImageLiteral.imgBeforeSelected2)
+        lowerPointView.pointText
+            .onNext(PointText.lower.rawValue)
+        
+        middlePointView.image
+            .onNext(ImageLiteral.imgBeforeSelected3)
+        middlePointView.pointText
+            .onNext(PointText.middle.rawValue)
+        
+        higherPointView.image
+            .onNext(ImageLiteral.imgBeforeSelected4)
+        higherPointView.pointText
+            .onNext(PointText.higher.rawValue)
+        
+        highestPointView.image
+            .onNext(ImageLiteral.imgBeforeSelected5)
+        highestPointView.pointText
+            .onNext(PointText.highest.rawValue)
+    }
+    
+    /// 스택뷰에서 탭된 이미지만 after select로 변경
+    func selectPointView() {
+        lowestPointView.pointButton.rx.tap
+            .subscribe(onNext: { [unowned self] in
+                self.fillSelected.onNext(true)
+                
+                self.lowestPointView.pointButton.setBackgroundImage(ImageLiteral.imgAfterSelected1, for: .normal)
+                self.lowestPointView.pointLabel.textColor = .primary
+                
+                self.lowerPointView.pointButton.setBackgroundImage(ImageLiteral.imgBeforeSelected2, for: .normal)
+                self.lowerPointView.pointLabel.textColor = .gray02
+                
+                self.middlePointView.pointButton.setBackgroundImage(ImageLiteral.imgBeforeSelected3, for: .normal)
+                self.middlePointView.pointLabel.textColor = .gray02
+                
+                self.higherPointView.pointButton.setBackgroundImage(ImageLiteral.imgBeforeSelected4, for: .normal)
+                self.higherPointView.pointLabel.textColor = .gray02
+                
+                self.highestPointView.pointButton.setBackgroundImage(ImageLiteral.imgBeforeSelected5, for: .normal)
+                self.highestPointView.pointLabel.textColor = .gray02
+            })
+            .disposed(by: disposeBag)
+        
+        lowerPointView.pointButton.rx.tap
+            .subscribe(onNext: {
+                self.fillSelected.onNext(true)
+                
+                self.lowestPointView.pointButton.setBackgroundImage(ImageLiteral.imgBeforeSelected1, for: .normal)
+                self.lowestPointView.pointLabel.textColor = .gray02
+                
+                self.lowerPointView.pointButton.setBackgroundImage(ImageLiteral.imgAfterSelected2, for: .normal)
+                self.lowerPointView.pointLabel.textColor = .primary
+                
+                self.middlePointView.pointButton.setBackgroundImage(ImageLiteral.imgBeforeSelected3, for: .normal)
+                self.middlePointView.pointLabel.textColor = .gray02
+                
+                self.higherPointView.pointButton.setBackgroundImage(ImageLiteral.imgBeforeSelected4, for: .normal)
+                self.higherPointView.pointLabel.textColor = .gray02
+                
+                self.highestPointView.pointButton.setBackgroundImage(ImageLiteral.imgBeforeSelected5, for: .normal)
+                self.highestPointView.pointLabel.textColor = .gray02
+                
+            })
+            .disposed(by: disposeBag)
+        
+        middlePointView.pointButton.rx.tap
+            .subscribe(onNext: {
+                self.fillSelected.onNext(true)
+                
+                self.lowestPointView.pointButton.setBackgroundImage(ImageLiteral.imgBeforeSelected1, for: .normal)
+                self.lowestPointView.pointLabel.textColor = .gray02
+                
+                self.lowerPointView.pointButton.setBackgroundImage(ImageLiteral.imgBeforeSelected2, for: .normal)
+                self.lowerPointView.pointLabel.textColor = .gray02
+                
+                self.middlePointView.pointButton.setBackgroundImage(ImageLiteral.imgAfterSelected3, for: .normal)
+                self.middlePointView.pointLabel.textColor = .primary
+                
+                self.higherPointView.pointButton.setBackgroundImage(ImageLiteral.imgBeforeSelected4, for: .normal)
+                self.higherPointView.pointLabel.textColor = .gray02
+                
+                self.highestPointView.pointButton.setBackgroundImage(ImageLiteral.imgBeforeSelected5, for: .normal)
+                self.highestPointView.pointLabel.textColor = .gray02
+                
+            })
+            .disposed(by: disposeBag)
+        
+        higherPointView.pointButton.rx.tap
+            .subscribe(onNext: {
+                self.fillSelected.onNext(true)
+                
+                self.lowestPointView.pointButton.setBackgroundImage(ImageLiteral.imgBeforeSelected1, for: .normal)
+                self.lowestPointView.pointLabel.textColor = .gray02
+                
+                self.lowerPointView.pointButton.setBackgroundImage(ImageLiteral.imgBeforeSelected2, for: .normal)
+                self.lowerPointView.pointLabel.textColor = .gray02
+                
+                self.middlePointView.pointButton.setBackgroundImage(ImageLiteral.imgBeforeSelected3, for: .normal)
+                self.middlePointView.pointLabel.textColor = .gray02
+                
+                self.higherPointView.pointButton.setBackgroundImage(ImageLiteral.imgAfterSelected4, for: .normal)
+                self.higherPointView.pointLabel.textColor = .primary
+                
+                self.highestPointView.pointButton.setBackgroundImage(ImageLiteral.imgBeforeSelected5, for: .normal)
+                self.highestPointView.pointLabel.textColor = .gray02
+                
+            })
+            .disposed(by: disposeBag)
+        
+        highestPointView.pointButton.rx.tap
+            .subscribe(onNext: {
+                self.fillSelected.onNext(true)
+                
+                self.lowestPointView.pointButton.setBackgroundImage(ImageLiteral.imgBeforeSelected1, for: .normal)
+                self.lowestPointView.pointLabel.textColor = .gray02
+                
+                self.lowerPointView.pointButton.setBackgroundImage(ImageLiteral.imgBeforeSelected2, for: .normal)
+                self.lowerPointView.pointLabel.textColor = .gray02
+                
+                self.middlePointView.pointButton.setBackgroundImage(ImageLiteral.imgBeforeSelected3, for: .normal)
+                self.middlePointView.pointLabel.textColor = .gray02
+                
+                self.higherPointView.pointButton.setBackgroundImage(ImageLiteral.imgBeforeSelected4, for: .normal)
+                self.higherPointView.pointLabel.textColor = .gray02
+                
+                self.highestPointView.pointButton.setBackgroundImage(ImageLiteral.imgAfterSelected5, for: .normal)
+                self.highestPointView.pointLabel.textColor = .primary
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    func validateInput() {
+        let textViewObservable = textView.rx.text
+            .compactMap { $0 }
+            .map {
+                $0 != "자유롭게 회고를 작성해보세요!" && !$0.isEmpty
+            }
+        
+        Observable.combineLatest(textViewObservable, fillSelected.asObservable()) { lhs, rhs in
+            return lhs && rhs
+        }
+        .subscribe(onNext: { [unowned self] in
+            if $0 {
+                self.registerButton.isEnabled = true
+                self.registerButton.backgroundColor = .primary
+            } else {
+                self.registerButton.isEnabled = false
+                self.registerButton.backgroundColor = .gray01
+            }
+        })
+        .disposed(by: disposeBag)
+    }
 }

--- a/Milestone/Milestone/Screens/CompletionBox/View/IndexView.swift
+++ b/Milestone/Milestone/Screens/CompletionBox/View/IndexView.swift
@@ -22,14 +22,18 @@ class IndexView: UIView {
             $0.font = UIFont.pretendard(.semibold, ofSize: 16)
         }
     
-    private let textView = UITextView()
+    let textView = UITextView()
         .then {
-            $0.textContainerInset = .init(top: 24, left: 24, bottom: 24, right: 24)
-            $0.textColor = .gray02
+            $0.textContainerInset = UIEdgeInsets(top: 24, left: 24, bottom: 24, right: 24)
             $0.font = UIFont.pretendard(.regular, ofSize: 14)
             $0.text = "내용을 입력해주세요!"
             $0.layer.cornerRadius = 20
             $0.backgroundColor = .gray01
+            
+            let style = NSMutableParagraphStyle()
+            style.lineHeightMultiple = 1.3
+            let attributes = [NSMutableAttributedString.Key.paragraphStyle: style, NSMutableAttributedString.Key.font: UIFont.pretendard(.regular, ofSize: 14), NSMutableAttributedString.Key.foregroundColor: UIColor.gray02]
+            $0.attributedText = NSAttributedString(string: $0.text, attributes: attributes)
         }
     
     private let textCountLabel = UILabel()
@@ -71,7 +75,7 @@ class IndexView: UIView {
             make.leading.equalTo(self.snp.leading).offset(24)
             make.trailing.equalTo(self.snp.trailing).offset(-24)
             make.top.equalTo(indexView.snp.bottom).offset(16)
-            make.height.equalTo(204)
+            make.height.equalTo(220)
         }
         
         textCountLabel.snp.makeConstraints { make in
@@ -108,6 +112,14 @@ class IndexView: UIView {
             .compactMap { $0 }
             .map { "\($0 == "내용을 입력해주세요!" ? 0 : $0.count)/200" }
             .bind(to: textCountLabel.rx.text)
+            .disposed(by: disposeBag)
+        
+        textView.rx.text
+            .compactMap { $0 }
+            .scan("") { previous, new in
+                return new.count <= 200 ? new : previous
+            }
+            .bind(to: textView.rx.text)
             .disposed(by: disposeBag)
     }
 }


### PR DESCRIPTION
## 상세 내용

- #48 

https://github.com/dnd-side-project/dnd-9th-1-ios/assets/75518683/7bff3c8b-d5c5-4a1d-b48f-b3faa9943d80


https://github.com/dnd-side-project/dnd-9th-1-ios/assets/75518683/3fc0a334-0984-489a-9bb7-ff9954da5902


<br/>

## 이슈 1. 마일이 질문받기 로직 개선
1. 각 텍스트뷰들을 직접 rx속성으로 참조하여 빈 문자가 아니면서 && 플레이스홀더 문자가 아닌 경우에 대한 `Observable<Bool>` 값을 선언했습니다.
2. 스택뷰 내부 버튼 클릭시 이미지 활성화를 위해 엄청 긴 코드 내에 next 이벤트를 방출하는 부분이 있는데, 이때 뷰컨 속성에 `fillSelected`라는 불리언 퍼블리시 서브젝트를 두고 이벤트를 받고, 최종적으로 validate 함수를 정의하여 모든 옵저버블들을 combine해주었습니다.
3. combine으로 나온 결과값 불리언을 기준으로 true일때 버튼을 활성화 하고, 아닐때는 disabled 해주었습니다 👍 

## 이슈 2. 상단 바 그림자 부여
1. 그림자를 부여할때 상단 바에 백그라운드 컬러 설정이 안되어 있어서 상단 바의 서브뷰로 등록된 캘린더 이미지나 UILabel 요소들의 그림자가 비춰지는 문제가 있었습니다 .. 왤캐 나 멍청하냐

## 이슈 3. 텍스트뷰 행간 부여
1. 피곤해서 머리가 안돌아갔습니다,, 여기서 쓸데없이 시간 넘 많이 잡아먹음 👎 
2. 텍스트뷰 then으로 내부에서 attrbutedText 초기 설정만 해주면 나중에는 text값만 세팅해도 자동으로 attributedText로 적용되더랍니다

## 기타
1. 완료함 뷰컨에서 viewDidAppear 시점에 디스포저블을 직접 해제하기 위해 변수에 담아뒀었는데, 옵셔널 언래핑 에러가 발생하여 nil로 설정했습니다. 에러도 없고 비정상적인 동작도 안하네요
2. 스택 오버플로우 [링크](https://stackoverflow.com/questions/36805449/is-it-safe-to-use-unowned-self-in-rxswift-drivers)입니다. `unowned`에 대한 이야기인데, disposeBag이랑 사용하는 옵저버블은 클로저 내에서 unowned를 사용해도 안전하다고 하네요 👍  이유를 좀 찾아보고 싶은데 일단 프로젝트 마무리부터 하고.. 찾아보겠습니다! unowned 다 적용하고 있는데 크래시도 안나고 언래핑도 필요없어서 편하네요 👍 👍 👍 

<br/>

## 셀프 체크리스트
- [ ] Merge 하는 브랜치가 올바른가?
- [ ] 코딩 컨벤션을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 오른쪽의 Development에서 이슈와 연결하였는가?
