### PR TITLE
[#44] 세부 목표 추가 모달 뷰 구현

### DIFF
--- a/Milestone/Milestone.xcodeproj/project.pbxproj
+++ b/Milestone/Milestone.xcodeproj/project.pbxproj
@@ -32,6 +32,12 @@
 		A265090C2A8D458300E9A2D7 /* BubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A265090B2A8D458300E9A2D7 /* BubbleView.swift */; };
 		A265090D2A8D458300E9A2D7 /* BubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A265090B2A8D458300E9A2D7 /* BubbleView.swift */; };
 		A265090E2A8D458300E9A2D7 /* BubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A265090B2A8D458300E9A2D7 /* BubbleView.swift */; };
+		A27C9A0C2A8E4258002C6F44 /* AddDetailGoalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A27C9A0B2A8E4258002C6F44 /* AddDetailGoalViewController.swift */; };
+		A27C9A0D2A8E4258002C6F44 /* AddDetailGoalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A27C9A0B2A8E4258002C6F44 /* AddDetailGoalViewController.swift */; };
+		A27C9A0E2A8E4258002C6F44 /* AddDetailGoalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A27C9A0B2A8E4258002C6F44 /* AddDetailGoalViewController.swift */; };
+		A27C9A102A8E42B5002C6F44 /* EnterGoalAlarmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A27C9A0F2A8E42B5002C6F44 /* EnterGoalAlarmView.swift */; };
+		A27C9A112A8E42B5002C6F44 /* EnterGoalAlarmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A27C9A0F2A8E42B5002C6F44 /* EnterGoalAlarmView.swift */; };
+		A27C9A122A8E42B5002C6F44 /* EnterGoalAlarmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A27C9A0F2A8E42B5002C6F44 /* EnterGoalAlarmView.swift */; };
 		A28EDA112A87808A001A021A /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A28EDA102A87808A001A021A /* UIViewController+.swift */; };
 		A28EDA122A87808A001A021A /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A28EDA102A87808A001A021A /* UIViewController+.swift */; };
 		A28EDA132A87808A001A021A /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A28EDA102A87808A001A021A /* UIViewController+.swift */; };
@@ -236,6 +242,8 @@
 		A227368B2A7CE53800D7B3B2 /* MilestoneUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MilestoneUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		A23075C92A87F8EE00D841F6 /* DetailGoal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailGoal.swift; sourceTree = "<group>"; };
 		A265090B2A8D458300E9A2D7 /* BubbleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BubbleView.swift; sourceTree = "<group>"; };
+		A27C9A0B2A8E4258002C6F44 /* AddDetailGoalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddDetailGoalViewController.swift; sourceTree = "<group>"; };
+		A27C9A0F2A8E42B5002C6F44 /* EnterGoalAlarmView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnterGoalAlarmView.swift; sourceTree = "<group>"; };
 		A28EDA102A87808A001A021A /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
 		A28EDA142A8791F7001A021A /* DetailGoalCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailGoalCollectionViewCell.swift; sourceTree = "<group>"; };
 		A28EDA182A879565001A021A /* DetailParentViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetailParentViewController.swift; sourceTree = "<group>"; };
@@ -556,12 +564,14 @@
 				A2C98F052A8B6122009B5579 /* EnterGoalTitleView.swift */,
 				A2C98F0D2A8B7A99009B5579 /* EnterGoalDateView.swift */,
 				A2C98F112A8B9A8E009B5579 /* ReminderAlarmView.swift */,
+				A27C9A0F2A8E42B5002C6F44 /* EnterGoalAlarmView.swift */,
 				A2C98F152A8BA6F0009B5579 /* RoundedDarkButton.swift */,
 				A2D304BC2A854E4000A5BA92 /* FillBoxViewController.swift */,
 				A28EDA182A879565001A021A /* DetailParentViewController.swift */,
 				A2248E862A8A076D00EB995A /* MoreViewController.swift */,
 				A2EC47CB2A8A962600401B03 /* DetailGoalInfoViewController.swift */,
 				A2C98F012A8B6117009B5579 /* AddParentGoalViewController.swift */,
+				A27C9A0B2A8E4258002C6F44 /* AddDetailGoalViewController.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -932,6 +942,7 @@
 				A2C98F0E2A8B7A99009B5579 /* EnterGoalDateView.swift in Sources */,
 				A2B969822A85750600C4903F /* MainViewController.swift in Sources */,
 				A2FA59192A7FD2CF006ACA2E /* BaseViewController.swift in Sources */,
+				A27C9A102A8E42B5002C6F44 /* EnterGoalAlarmView.swift in Sources */,
 				A2248E8B2A8A0C5400EB995A /* MoreOptionView.swift in Sources */,
 				A265090C2A8D458300E9A2D7 /* BubbleView.swift in Sources */,
 				C9B2CDDB2A8B1EBC006289A8 /* CompletionAlertView.swift in Sources */,
@@ -975,6 +986,7 @@
 				C90DC9822A88854C00241B7C /* OnboardingViewController.swift in Sources */,
 				C9B2CDDE2A8B42CA006289A8 /* CompletionTableViewCell.swift in Sources */,
 				A22736692A7CE53700D7B3B2 /* AppDelegate.swift in Sources */,
+				A27C9A0C2A8E4258002C6F44 /* AddDetailGoalViewController.swift in Sources */,
 				A2B20D612A7E4FAD001ED73C /* UIView+.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1006,6 +1018,7 @@
 				A2D304CA2A856B6B00A5BA92 /* StorageBoxViewController.swift in Sources */,
 				A2FA592E2A7FD433006ACA2E /* NSObject+.swift in Sources */,
 				A2FA59152A7FCFC8006ACA2E /* Data+.swift in Sources */,
+				A27C9A112A8E42B5002C6F44 /* EnterGoalAlarmView.swift in Sources */,
 				A2FA591A2A7FD2CF006ACA2E /* BaseViewController.swift in Sources */,
 				A2FA592A2A7FD3BA006ACA2E /* UITableView+.swift in Sources */,
 				A2C98F032A8B6117009B5579 /* AddParentGoalViewController.swift in Sources */,
@@ -1013,6 +1026,7 @@
 				A2B20D912A7ED14C001ED73C /* ImageLiteral.swift in Sources */,
 				A2EC47D12A8A968A00401B03 /* DetailGoalInfoView.swift in Sources */,
 				A28EDA1A2A879565001A021A /* DetailParentViewController.swift in Sources */,
+				A27C9A0D2A8E4258002C6F44 /* AddDetailGoalViewController.swift in Sources */,
 				A2248E882A8A076D00EB995A /* MoreViewController.swift in Sources */,
 				A2B20D5A2A7E4E5C001ED73C /* UIFont+.swift in Sources */,
 				A2248E962A8A5A5C00EB995A /* CompletionBoxViewController.swift in Sources */,
@@ -1034,6 +1048,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A2248E892A8A076D00EB995A /* MoreViewController.swift in Sources */,
+				A27C9A0E2A8E4258002C6F44 /* AddDetailGoalViewController.swift in Sources */,
 				A265090E2A8D458300E9A2D7 /* BubbleView.swift in Sources */,
 				A2FA58DF2A7F7A3E006ACA2E /* Requestable.swift in Sources */,
 				A2B20D672A7E5077001ED73C /* UILabel+.swift in Sources */,
@@ -1055,6 +1070,7 @@
 				A2248E8D2A8A0C5400EB995A /* MoreOptionView.swift in Sources */,
 				A2248E852A8818AD00EB995A /* DetailGoalTableViewCell.swift in Sources */,
 				A2D304CB2A856B6B00A5BA92 /* StorageBoxViewController.swift in Sources */,
+				A27C9A122A8E42B5002C6F44 /* EnterGoalAlarmView.swift in Sources */,
 				A28EDA1B2A879565001A021A /* DetailParentViewController.swift in Sources */,
 				A2FA59232A7FD2EC006ACA2E /* BaseTableViewCell.swift in Sources */,
 				A2FA58E32A7F7A4A006ACA2E /* APIService.swift in Sources */,

--- a/Milestone/Milestone/Screens/FillBox/View/AddDetailGoalViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/AddDetailGoalViewController.swift
@@ -1,0 +1,122 @@
+//
+//  AddDetailGoalViewController.swift
+//  Milestone
+//
+//  Created by 서은수 on 2023/08/17.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+// MARK: - 하위 목표 추가 모달뷰
+
+class AddDetailGoalViewController: BaseViewController {
+    
+    // MARK: - SubViews
+    
+    lazy var backButton = UIButton()
+        .then {
+            $0.setImage(ImageLiteral.imgBack, for: .normal)
+            $0.addTarget(self, action: #selector(dismissAddDetailGoal), for: .touchUpInside)
+        }
+    var topicLabel = UILabel()
+        .then {
+            $0.text = "목표 설정"
+            $0.font = .pretendard(.semibold, ofSize: 18)
+            $0.textAlignment = .center
+        }
+    lazy var enterGoalTitleView = EnterGoalTitleView()
+        .then {
+            $0.delegate = self
+        }
+    lazy var enterGoalAlarmView = EnterGoalAlarmView()
+        .then {
+            $0.delegate = self
+        }
+    lazy var completeButton = RoundedDarkButton()
+        .then {
+            $0.addTarget(self, action: #selector(completeAddDetailGoal), for: .touchUpInside)
+        }
+    
+    // MARK: - Properties
+    
+    let viewHeight = 549.0
+    
+    // MARK: - Functions
+    
+    override func render() {
+        view.addSubViews([backButton, topicLabel, enterGoalTitleView, enterGoalAlarmView, completeButton])
+        
+        view.snp.makeConstraints { make in
+            make.width.equalTo(UIScreen.main.bounds.width)
+        }
+        backButton.snp.makeConstraints { make in
+            make.top.equalTo(28)
+            make.left.equalTo(32)
+            make.width.equalTo(9)
+            make.height.equalTo(17)
+        }
+        topicLabel.snp.makeConstraints { make in
+            make.top.equalToSuperview().inset(24)
+            make.centerX.equalToSuperview()
+        }
+        enterGoalTitleView.snp.makeConstraints { make in
+            make.top.equalTo(topicLabel.snp.bottom).offset(32)
+            make.centerX.equalToSuperview()
+        }
+        enterGoalAlarmView.snp.makeConstraints { make in
+            make.top.equalTo(enterGoalTitleView.snp.bottom).offset(32)
+            make.centerX.equalToSuperview()
+        }
+        completeButton.snp.makeConstraints { make in
+            make.left.right.equalToSuperview().inset(24)
+            make.bottom.equalTo(view.safeAreaLayoutGuide).offset(-16)
+            make.height.equalTo(54)
+        }
+    }
+
+    override func configUI() {
+        view.backgroundColor = .white
+        view.layer.masksToBounds = true
+        view.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+        view.layer.cornerRadius = 20
+        view.makeShadow(color: .init(hex: "#464646", alpha: 0.2), alpha: 1, x: 0, y: -10, blur: 20, spread: 0)
+        
+        completeButton.titleString = "목표 만들기 완료"
+    }
+    
+    // MARK: - @objc Functions
+    
+    @objc
+    private func dismissAddDetailGoal() {
+        self.dismiss(animated: true)
+    }
+    
+    @objc
+    private func completeAddDetailGoal() {
+        updateButtonState(.press)
+        
+        // 버튼 업데이트 보여주기 위해 0.1초만 딜레이 후 dismiss
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            self.dismiss(animated: true)
+        }
+    }
+}
+
+// MARK: - PresentAlertDelegate
+
+extension AddDetailGoalViewController: PresentAlertDelegate {
+    func present(alert: UIAlertController) {
+        self.present(alert, animated: true)
+    }
+}
+
+// MARK: - UpdateButtonStateDelegate
+
+extension AddDetailGoalViewController: UpdateButtonStateDelegate {
+    func updateButtonState(_ state: ButtonState) {
+        self.completeButton.buttonState = state
+    }
+}

--- a/Milestone/Milestone/Screens/FillBox/View/AddDetailGoalViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/AddDetailGoalViewController.swift
@@ -37,6 +37,7 @@ class AddDetailGoalViewController: BaseViewController {
         }
     lazy var completeButton = RoundedDarkButton()
         .then {
+            $0.titleString = "목표 만들기 완료"
             $0.addTarget(self, action: #selector(completeAddDetailGoal), for: .touchUpInside)
         }
     
@@ -83,8 +84,6 @@ class AddDetailGoalViewController: BaseViewController {
         view.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
         view.layer.cornerRadius = 20
         view.makeShadow(color: .init(hex: "#464646", alpha: 0.2), alpha: 1, x: 0, y: -10, blur: 20, spread: 0)
-        
-        completeButton.titleString = "목표 만들기 완료"
     }
     
     // MARK: - @objc Functions
@@ -108,6 +107,10 @@ class AddDetailGoalViewController: BaseViewController {
 // MARK: - PresentAlertDelegate
 
 extension AddDetailGoalViewController: PresentAlertDelegate {
+    func present(vc: UIViewController) {
+        self.present(vc, animated: true)
+    }
+    
     func present(alert: UIAlertController) {
         self.present(alert, animated: true)
     }

--- a/Milestone/Milestone/Screens/FillBox/View/AddParentGoalViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/AddParentGoalViewController.swift
@@ -16,6 +16,7 @@ import Then
 /// 서브뷰에서 present 시 사용함
 protocol PresentAlertDelegate: AnyObject {
     func present(alert: UIAlertController)
+    func present(vc: UIViewController)
 }
 
 /// 버튼의 상태를 업데이트 해주는 델리게이트 패턴
@@ -128,6 +129,9 @@ class AddParentGoalViewController: BaseViewController {
 extension AddParentGoalViewController: PresentAlertDelegate {
     func present(alert: UIAlertController) {
         self.present(alert, animated: true)
+    }
+    func present(vc: UIViewController) {
+        self.present(vc, animated: true)
     }
 }
 

--- a/Milestone/Milestone/Screens/FillBox/View/DetailParentViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/DetailParentViewController.swift
@@ -221,11 +221,24 @@ extension DetailParentViewController: UICollectionViewDataSource, UICollectionVi
         return cell
     }
     
+    // MARK: - @objc Functions
+    
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let detailInfo = DetailGoalInfoViewController()
-        detailInfo.modalPresentationStyle = .overFullScreen
-        detailInfo.modalTransitionStyle = .crossDissolve
-        self.present(detailInfo, animated: true)
+        guard let cell = collectionView.cellForItem(at: indexPath) as? DetailGoalCollectionViewCell else { return }
+        if cell.isSet.value {
+            let detailInfo = DetailGoalInfoViewController()
+            detailInfo.modalPresentationStyle = .overFullScreen
+            detailInfo.modalTransitionStyle = .crossDissolve
+            self.present(detailInfo, animated: true)
+        } else {
+            let addDetailGoalVC = AddDetailGoalViewController()
+            addDetailGoalVC.modalPresentationStyle = .pageSheet
+            
+            guard let sheet = addDetailGoalVC.sheetPresentationController else { return }
+            let fraction = UISheetPresentationController.Detent.custom { _ in 500.0 }
+            sheet.detents = [fraction]
+            present(addDetailGoalVC, animated: true)
+        }
     }
 }
 

--- a/Milestone/Milestone/Screens/FillBox/View/EnterGoalAlarmView.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/EnterGoalAlarmView.swift
@@ -42,6 +42,7 @@ class EnterGoalAlarmView: UIView {
         .then {
             $0.isOn = true
             $0.onTintColor = .primary
+            $0.addTarget(self, action: #selector(toggleAlarmSwitch), for: .valueChanged)
         }
     var dayButton = UIButton()
     lazy var dayStackView = UIStackView()
@@ -100,13 +101,12 @@ class EnterGoalAlarmView: UIView {
     
     // MARK: - Properties
     
-    var timePickerData = [["오전", "오후"], ["01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12"], ["00", "30"]]
-    var dayList = [DayData(day: Days.MONDAY.rawValue), DayData(day: Days.TUEDAY.rawValue), DayData(day: Days.WEDDAY.rawValue), DayData(day: Days.THUDAY.rawValue), DayData(day: Days.FRIDAY.rawValue), DayData(day: Days.SATDAY.rawValue), DayData(day: Days.SUNDAY.rawValue)]
     weak var delegate: (PresentAlertDelegate)?
-    var isSelected: Bool = true
-    var selectedAmOrPm = "오후"
-    var selectedHour = "01"
-    var selectedMin = "00"
+    private var timePickerData = [["오전", "오후"], ["01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12"], ["00", "30"]]
+    private var dayList = [DayData(day: Days.MONDAY.rawValue), DayData(day: Days.TUEDAY.rawValue), DayData(day: Days.WEDDAY.rawValue), DayData(day: Days.THUDAY.rawValue), DayData(day: Days.FRIDAY.rawValue), DayData(day: Days.SATDAY.rawValue), DayData(day: Days.SUNDAY.rawValue)]
+    private var selectedAmOrPm = "오후"
+    private var selectedHour = "01"
+    private var selectedMin = "00"
     
     // MARK: - Initialization
     
@@ -194,6 +194,11 @@ class EnterGoalAlarmView: UIView {
     }
     
     // MARK: - @objc Functions
+    
+    @objc
+    private func toggleAlarmSwitch() {
+        [dayStackView, timeButton, receiveAlarmLabel].forEach { $0.isHidden = !onOffSwitch.isOn }
+    }
     
     /// 요일 버튼 클릭 시 실행
     /// dayList에서 해당 인덱스의 isSelected 값을 토글하고

--- a/Milestone/Milestone/Screens/FillBox/View/EnterGoalAlarmView.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/EnterGoalAlarmView.swift
@@ -1,0 +1,210 @@
+//
+//  EnterGoalAlarmView.swift
+//  Milestone
+//
+//  Created by 서은수 on 2023/08/17.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+struct DayData: Equatable { // TEMP
+    var day: String
+    var isSelected: Bool = false
+}
+
+enum Days: String {
+    case MONDAY = "월"
+    case TUEDAY = "화"
+    case WEDDAY = "수"
+    case THUDAY = "목"
+    case FRIDAY = "금"
+    case SATDAY = "토"
+    case SUNDAY = "일"
+}
+
+// MARK: - 목표 알람 설정 뷰
+
+class EnterGoalAlarmView: UIView {
+    
+    // MARK: - Subviews
+    
+    let guideLabel = UILabel()
+        .then {
+            $0.text = "알람 상태"
+            $0.textAlignment = .left
+            $0.font = .pretendard(.semibold, ofSize: 16)
+            $0.textColor = .black
+        }
+    lazy var onOffSwitch = UISwitch()
+        .then {
+            $0.isOn = true
+            $0.onTintColor = .primary
+        }
+    var dayButton = UIButton()
+    lazy var dayStackView = UIStackView()
+        .then {
+            $0.axis = .horizontal
+            $0.spacing = 8
+            $0.distribution = .fillEqually
+            for i in dayList {
+                dayButton = UIButton()
+                    .then {
+                        $0.setTitle(i.day, for: .normal)
+                        $0.titleLabel?.font = .pretendard(.semibold, ofSize: 16)
+                        $0.setTitleColor(.black, for: .normal)
+                        $0.backgroundColor = .gray01
+                        $0.clipsToBounds = true
+                        $0.layer.cornerRadius = 10
+                        $0.addTarget(self, action: #selector(selectAlarmDay(_:)), for: .touchUpInside)
+                        if i.day == Days.MONDAY.rawValue {
+                            selectAlarmDay($0)
+                        }
+                    }
+                $0.addArrangedSubview(dayButton)
+            }
+        }
+    lazy var timeButton = UIButton()
+        .then {
+            $0.backgroundColor = .gray01
+            $0.setTitle("오후   01 : 00", for: .normal)
+            $0.layer.cornerRadius = 10
+            $0.setTitleColor(.black, for: .normal)
+            $0.titleLabel?.font = .pretendard(.semibold, ofSize: 16)
+            $0.addTarget(self, action: #selector(presentTimeAlert), for: .touchUpInside)
+        }
+    lazy var receiveAlarmLabel = UILabel()
+        .then {
+            $0.text = "에 알람을 받을게요!"
+            $0.textAlignment = .left
+            $0.font = .pretendard(.semibold, ofSize: 14)
+            $0.textColor = .black
+        }
+    lazy var timeSelectPicker = UIDatePicker()
+        .then {
+            $0.datePickerMode = .time
+            $0.preferredDatePickerStyle = .wheels
+            $0.minuteInterval = 30
+            $0.locale = Locale(identifier: "ko_KR")
+        }
+    lazy var timeSelectAlert = UIAlertController(title: nil, message: "시간을 선택해주세요", preferredStyle: .actionSheet)
+        .then {
+            $0.addAction(timeSelectAction)
+        }
+    lazy var timeSelectAction = UIAlertAction(title: "완료", style: .default) { [self] _ in
+        timeButton.setTitle("\(dateFormatter.string(from: timeSelectPicker.date))", for: .normal)
+    }
+    let timeSelectViewController = UIViewController()
+    
+    // MARK: - Properties
+    
+    var dayList = [DayData(day: Days.MONDAY.rawValue), DayData(day: Days.TUEDAY.rawValue), DayData(day: Days.WEDDAY.rawValue), DayData(day: Days.THUDAY.rawValue), DayData(day: Days.FRIDAY.rawValue), DayData(day: Days.SATDAY.rawValue), DayData(day: Days.SUNDAY.rawValue)]
+    let dateFormatter = DateFormatter()
+        .then {
+            $0.dateFormat = "a   hh : mm"
+        }
+    weak var delegate: (PresentAlertDelegate)?
+    var isSelected: Bool = true
+    
+    // MARK: - Initialization
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        render()
+        configUI()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Functions
+    
+    private func render() {
+        addSubViews([guideLabel, onOffSwitch, dayStackView, timeButton, receiveAlarmLabel])
+        
+        self.snp.makeConstraints { make in
+            make.width.equalTo(342)
+            make.height.equalTo(136)
+        }
+        guideLabel.snp.makeConstraints { make in
+            make.top.equalToSuperview().inset(3)
+            make.left.equalToSuperview()
+        }
+        onOffSwitch.snp.makeConstraints { make in
+            make.centerY.equalTo(guideLabel)
+            make.right.equalToSuperview()
+        }
+        dayStackView.snp.makeConstraints { make in
+            make.top.equalTo(guideLabel.snp.bottom).offset(20)
+            make.left.equalTo(guideLabel)
+            make.right.equalTo(onOffSwitch)
+            make.height.equalTo(42)
+        }
+        timeButton.snp.makeConstraints { make in
+            make.top.equalTo(dayStackView.snp.bottom).offset(8)
+            make.left.equalTo(dayStackView)
+            make.width.equalTo(136)
+            make.height.equalTo(42)
+        }
+        receiveAlarmLabel.snp.makeConstraints { make in
+            make.left.equalTo(timeButton.snp.right).offset(8)
+            make.centerY.equalTo(timeButton)
+        }
+    }
+    
+    private func configUI() {
+        timeSelectViewController.view = timeSelectPicker
+    }
+    
+    /// 상황에 따라 버튼의 스타일을 업데이트 해줌
+    private func updateStyleOf(_ button: UIButton, index: Int) {
+        if dayList[index].isSelected {
+            button.backgroundColor = .primary
+            button.setTitleColor(.white, for: .normal)
+        } else {
+            button.backgroundColor = .gray01
+            button.setTitleColor(.black, for: .normal)
+        }
+    }
+    
+    /// 요일 값이 배열에서 몇번째에 위치한 값인지 반환해주는 함수
+    private func getIndexOf(_ element: String) -> Int? {
+        // 비교를 위해 dayList에서 String 타입의 day만 가지고 있는 배열을 구성
+        let dayStringList = dayList.map { dayData in
+            dayData.day
+        }
+        // 해당 String 배열에서 element 값이 몇 번째 인덱스인지 검색
+        return dayStringList.firstIndex(of: element)
+    }
+    
+    // MARK: - @objc Functions
+    
+    /// 요일 버튼 클릭 시 실행
+    /// dayList에서 해당 인덱스의 isSelected 값을 토글하고
+    /// 버튼의 스타일을 바꿔줌
+    @objc
+    private func selectAlarmDay(_ sender: UIButton) {
+        let selectedIndex = getIndexOf(sender.titleLabel?.text ?? "") ?? 0
+        dayList[selectedIndex].isSelected.toggle()
+        updateStyleOf(sender, index: selectedIndex)
+        
+        // TODO: - 서버에 값 전달 시 사용할 듯
+//        if let day = Days(rawValue: dayList[selectedIndex].day) {
+//            Logger.debugDescription(day)
+//        }
+    }
+    
+    /// 시간 설정 버튼 클릭 시 실행
+    /// 시간을 선택할 수 있는 DatePicker가 액션 시트 형태로 present 된다
+    @objc
+    private func presentTimeAlert() {
+        timeSelectAlert
+            .setValue(timeSelectViewController, forKey: "contentViewController")
+        delegate?.present(alert: timeSelectAlert)
+    }
+}


### PR DESCRIPTION
## 상세 내용
- #44 
- 세부 목표 추가 모달 뷰를 구현하였습니다.
- 상위 목표 상세 화면 (= 세부 목표를 볼 수 있는 화면)의 컬렉션뷰에서 `세부 목표를 추가해주세요!` 셀을 클릭하면 해당 모달 뷰가 뜨게끔 연결하였습니다.
- 상위 목표 추가 모달 뷰 구현할 때 컴포넌트화 해둔 거 재사용하였습니다.
- 월~일 버튼은 스택뷰 안에 버튼을 넣는 방식으로 구현하였습니다.
- 시간 선택 부분 뷰는 `DatePicker` 쓰다가 `PickerView`를 사용하여 구현 완료! (아이디어 제공: 경준팍)
- 알람 상태 off 시에는 관련 뷰가 숨겨지도록 처리하였습니다.

## 시연 영상
https://github.com/dnd-side-project/dnd-9th-1-ios/assets/87434861/198e549c-5bf0-4461-912b-96b878e2ce1d

## 기타
- 서버 쪽에서 알람 받을 것으로 선택한 요일 정보를 "월" 이런 식으로 말고 `MONDAY` 형태로 달라고 해서 `enum` 타입을 사용하여 케이스로 정의해두었습니다.
- `enum`을 사용하는 곳이 여기저기에 생기는 것 같아서 `enum`만 따로 저장하는 폴더를 `Global` 폴더 안에 만들어 두려고 합니다.

## 셀프 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩 컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 오른쪽의 Development에서 이슈와 연결하였는가?
