### PR TITLE
[#66] 채움함 하단의 플로팅 버튼 클릭 스타일 변경

### DIFF
--- a/Milestone/Milestone/Global/Extension/UIButton+.swift
+++ b/Milestone/Milestone/Global/Extension/UIButton+.swift
@@ -8,18 +8,18 @@
 import UIKit
 
 extension UIButton {
-//    func makeButtonShadow(color: UIColor = .black, alpha: Float, x: CGFloat, y: CGFloat, blur: CGFloat, spread: CGFloat) {
-//        layer.masksToBounds = false
-//        layer.shadowColor = color.cgColor
-//        layer.shadowOpacity = alpha
-//        layer.shadowOffset = CGSize(width: x, height: y)
-//        layer.shadowRadius = blur / 2.0
-//        if spread == 0 {
-//            layer.shadowPath = nil
-//        } else {
-//            let dx = -spread
-//            let rect = bounds.insetBy(dx: dx, dy: dx)
-//            layer.shadowPath = UIBezierPath(rect: rect).cgPath
-//        }
-//    }
+    func makeButtonShadow(color: UIColor = .black, alpha: Float, x: CGFloat, y: CGFloat, blur: CGFloat, spread: CGFloat) {
+        layer.masksToBounds = false
+        layer.shadowColor = color.cgColor
+        layer.shadowOpacity = alpha
+        layer.shadowOffset = CGSize(width: x, height: y)
+        layer.shadowRadius = blur / 2.0
+        if spread == 0 {
+            layer.shadowPath = nil
+        } else {
+            let dx = -spread
+            let rect = bounds.insetBy(dx: dx, dy: dx)
+            layer.shadowPath = UIBezierPath(rect: rect).cgPath
+        }
+    }
 }

--- a/Milestone/Milestone/Screens/FillBox/View/FillBoxViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/FillBoxViewController.swift
@@ -36,11 +36,7 @@ class FillBoxViewController: BaseViewController {
             $0.layer.cornerRadius = 64 / 2
             $0.setImage(ImageLiteral.imgPlus, for: .normal)
             $0.addTarget(self, action: #selector(presentAddParentGoal), for: .touchUpInside)
-            // 그림자 생성
-            $0.layer.shadowColor = UIColor.primary.cgColor
-            $0.layer.shadowOpacity = 0.6
-            $0.layer.shadowOffset = CGSize(width: 0, height: 4)
-            $0.layer.shadowRadius = 6 / 2.0
+            $0.makeButtonShadow(color: .primary, alpha: 0.6, x: 0, y: 4, blur: 6, spread: 0)
         }
     
     private let bubbleView = BubbleView()

--- a/Milestone/Milestone/Screens/FillBox/View/FillBoxViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/FillBoxViewController.swift
@@ -33,9 +33,10 @@ class FillBoxViewController: BaseViewController {
     lazy var addGoalButton = UIButton()
         .then {
             $0.backgroundColor = .primary
+            $0.configuration = .plain()
             $0.layer.cornerRadius = 64 / 2
             $0.setImage(ImageLiteral.imgPlus, for: .normal)
-            $0.addTarget(self, action: #selector(presentAddParentGoal), for: .touchUpInside)
+            $0.addTarget(self, action: #selector(tapAddParentGoalButton), for: .touchUpInside)
             $0.makeButtonShadow(color: .primary, alpha: 0.6, x: 0, y: 4, blur: 6, spread: 0)
         }
     
@@ -111,17 +112,28 @@ class FillBoxViewController: BaseViewController {
         bubbleView.removeFromSuperview()
     }
     
-    // MARK: - @objc Functions
-    
-    @objc
-    func presentAddParentGoal() {
+    private func presentAddParentGoal() {
         let addParentGoalVC = AddParentGoalViewController()
         addParentGoalVC.modalPresentationStyle = .pageSheet
         
         guard let sheet = addParentGoalVC.sheetPresentationController else { return }
         let fraction = UISheetPresentationController.Detent.custom { _ in addParentGoalVC.viewHeight }
         sheet.detents = [fraction]
-        present(addParentGoalVC, animated: true)
+        self.present(addParentGoalVC, animated: true)
+    }
+    
+    // MARK: - @objc Functions
+    
+    @objc
+    private func tapAddParentGoalButton() {
+        // 클릭 스타일로 배경색 변경
+        addGoalButton.backgroundColor = .init(hex: "#2B75D4")
+        
+        // 바뀐 배경색이 보일 수 있게 0.01초만 딜레이
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) { [self] in
+            addGoalButton.backgroundColor = .primary // 다시 색깔 복구
+            presentAddParentGoal() // 모달 뷰 띄우기
+        }
     }
 }
 


### PR DESCRIPTION
## 상세 내용
- #66 
- 플로팅 버튼의 pressed 스타일을 적용했습니다!
- 0.01초 딜레이를 주어 클릭 시 바뀌는 버튼의 배경색을 확인할 수 있게 구현했습니다.
- 또한 목표 추가 모달 뷰가 내려가고 다시 채움함 화면이 보일 때는 버튼이 원래의 색깔이어야 하기 때문에 그 부분도 고려해서 코드를 작성했습니다.

## 시연 영상
https://github.com/dnd-side-project/dnd-9th-1-ios/assets/87434861/530390fd-a41f-4bba-bb23-7c6e6238a2bd

## 셀프 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩 컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 오른쪽의 Development에서 이슈와 연결하였는가?
