### PR TITLE
[#73] 완료함의 말풍선 뷰를 BubbleView 컴포넌트로 교체

### DIFF
--- a/Milestone/Milestone/Screens/CompletionBox/View/CompletionBoxViewController.swift
+++ b/Milestone/Milestone/Screens/CompletionBox/View/CompletionBoxViewController.swift
@@ -45,19 +45,9 @@ class CompletionBoxViewController: BaseViewController, ViewModelBindableType {
             $0.register(cell: CompletionTableViewCell.self, forCellReuseIdentifier: CompletionTableViewCell.identifier)
         }
     
-    private let bubbleView = UIView()
+    private let bubbleView = BubbleView()
         .then {
-            $0.layer.cornerRadius = 20
-            $0.backgroundColor = .gray05
-        }
-    
-    private let triangle = TriangleView()
-    
-    private let bubbleLabel = UILabel()
-        .then {
-            $0.font = UIFont.pretendard(.semibold, ofSize: 14)
-            $0.textColor = .white
-            $0.text = "이룬 목표에 대한 회고를 자세히 기록해보세요!"
+            $0.guideLabel.text = "이룬 목표에 대한 회고를 자세히 기록해보세요!"
         }
     
     var tapDisposable: [Disposable] = []
@@ -151,7 +141,7 @@ class CompletionBoxViewController: BaseViewController, ViewModelBindableType {
     // MARK: functions
     
     override func render() {
-        view.addSubViews([emptyImageView, label, tableView, bubbleView, triangle])
+        view.addSubViews([emptyImageView, label, tableView])
         
         emptyImageView.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(100)
@@ -190,36 +180,18 @@ class CompletionBoxViewController: BaseViewController, ViewModelBindableType {
         tableViewScrollDisposable = tableView.rx.didScroll
             .subscribe { [weak self] _ in
                 self?.bubbleView.isHidden = true
-                self?.bubbleLabel.isHidden = true
-                self?.triangle.isHidden = true
             }
     }
     
     /// 테이블뷰 레이아웃 세팅 완료 후 정의해야할 레이아웃 대상들을 분리
     func setAdditionalLayout() {
-        triangle.backgroundColor = .clear
-        triangle.setNeedsDisplay()
-
-        triangle.snp.makeConstraints { make in
-            make.top.equalTo(tableView.visibleCells[1].snp.bottom).offset(16)
-            make.centerX.equalTo(view.snp.centerX)
-            make.width.equalTo(18)
-            make.height.equalTo(16)
-        }
-        
-        bubbleView.addSubview(bubbleLabel)
-
+        view.addSubview(bubbleView)
         bubbleView.snp.makeConstraints { make in
-            make.top.equalTo(triangle.snp.bottom).offset(-4)
-            make.centerX.equalTo(view.snp.centerX)
-            make.trailing.equalTo(view.snp.trailing).offset(-54)
-            make.leading.equalTo(view.snp.leading).offset(54)
-            make.height.equalTo(36)
-        }
-        
-        bubbleLabel.snp.makeConstraints { make in
-            make.centerY.equalTo(bubbleView.snp.centerY)
-            make.centerX.equalTo(bubbleView.snp.centerX)
+            make.top.equalTo(tableView.visibleCells[1].snp.bottom).offset(16)
+            make.centerX.equalToSuperview()
+            make.trailing.equalToSuperview().offset(-54)
+            make.leading.equalToSuperview().offset(54)
+            make.height.equalTo(45)
         }
     }
     
@@ -230,7 +202,6 @@ class CompletionBoxViewController: BaseViewController, ViewModelBindableType {
             UserDefaults.standard.set("", forKey: "showBubbleInCompleteBox")
         } else {
             bubbleView.isHidden = true
-            triangle.isHidden = true
             tableViewScrollDisposable?.dispose()
         }
     }


### PR DESCRIPTION
## 상세 내용
- #73 
- `triangle`, `bubbleView`, `bubbleLabel`로 구현되어 있던 완료함의 말풍선 뷰를 `BubbleView` 컴포넌트로 교체하여 개선하였습니다.

## 기타
- 잘 작동하는 것 확인함
- `enum` 타입의 `UserDefaults` 키 적용은 #72 가 머지된 후 진행할 예정 (= 아직 코치 마크 뷰에만 적용되어 있음)

## 셀프 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩 컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 오른쪽의 Development에서 이슈와 연결하였는가?
