### PR TITLE
[#86] UserDefaults의 key 값으로 enum을 적용하여 코드 개선

### DIFF
--- a/Milestone/Milestone/Global/Enum/UserDefaultsKeyStyle.swift
+++ b/Milestone/Milestone/Global/Enum/UserDefaultsKeyStyle.swift
@@ -10,4 +10,6 @@ import UIKit
 /// UserDefaults에 사용되는 key 값 모음
 enum UserDefaultsKeyStyle: String {
     case couchMark = "showCouchMark"
+    case bubbleInFillBox = "showBubbleInFillBox"
+    case bubbleInCompletionBox = "showBubbleInCompletionBox"
 }

--- a/Milestone/Milestone/Screens/CompletionBox/View/CompletionBoxViewController.swift
+++ b/Milestone/Milestone/Screens/CompletionBox/View/CompletionBoxViewController.swift
@@ -14,7 +14,8 @@ import Then
 
 class CompletionBoxViewController: BaseViewController, ViewModelBindableType {
     
-    // MARK: subviews
+    // MARK: - Subviews
+    
     private let emptyImageView = UIImageView()
         .then {
             $0.image = ImageLiteral.imgcompletionEmpty
@@ -65,10 +66,13 @@ class CompletionBoxViewController: BaseViewController, ViewModelBindableType {
     var nsAttributedStringDisposable: Disposable?
     var tableViewScrollDisposable: Disposable?
     
-    // MARK: Properties
-    var viewModel: CompletionViewModel!
+    // MARK: - Properties
     
-    // MARK: Life Cycle
+    var viewModel: CompletionViewModel!
+    var bubbleKey = UserDefaultsKeyStyle.bubbleInCompletionBox.rawValue
+    
+    // MARK: - Life Cycle
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -148,7 +152,7 @@ class CompletionBoxViewController: BaseViewController, ViewModelBindableType {
         nsAttributedStringDisposable?.dispose()
     }
     
-    // MARK: functions
+    // MARK: - Functions
     
     override func render() {
         view.addSubViews([emptyImageView, label, tableView, bubbleView, triangle])
@@ -225,9 +229,9 @@ class CompletionBoxViewController: BaseViewController, ViewModelBindableType {
     
     /// 처음이 맞는지 확인 -> 맞으면 말풍선 뷰 띄우기
     private func checkFirstCompletionBox() {
-        if UserDefaults.standard.string(forKey: "showBubbleInCompleteBox") == nil {
+        if !UserDefaults.standard.bool(forKey: bubbleKey) {
             bubbleView.isHidden = false
-            UserDefaults.standard.set("", forKey: "showBubbleInCompleteBox")
+            UserDefaults.standard.set(true, forKey: bubbleKey)
         } else {
             bubbleView.isHidden = true
             triangle.isHidden = true
@@ -235,6 +239,8 @@ class CompletionBoxViewController: BaseViewController, ViewModelBindableType {
         }
     }
 }
+
+// MARK: - UITableViewDelegate
 
 extension CompletionBoxViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
@@ -254,6 +260,8 @@ extension CompletionBoxViewController: UITableViewDelegate {
         return headerView
     }
 }
+
+// MARK: - RxTableViewSectionedAnimatedDataSource
 
 extension CompletionBoxViewController {
     private func dataSource() -> RxTableViewSectionedAnimatedDataSource<CompletionSectionModel> {

--- a/Milestone/Milestone/Screens/FillBox/View/DetailParentViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/DetailParentViewController.swift
@@ -186,7 +186,7 @@ class DetailParentViewController: BaseViewController {
     
     /// 여기 들어온 게 처음이 맞는지 확인 -> 맞으면 코치 마크 뷰 띄우기
     private func checkFirstDetailView() {
-        if UserDefaults.standard.string(forKey: couchMarkKey) == nil {
+        if !UserDefaults.standard.bool(forKey: couchMarkKey) {
             presentCouchMark()
         }
     }
@@ -199,7 +199,7 @@ class DetailParentViewController: BaseViewController {
                 $0.modalTransitionStyle = .crossDissolve
             }
         present(couchMarkVC, animated: true)
-        UserDefaults.standard.set("", forKey: couchMarkKey)
+        UserDefaults.standard.set(true, forKey: couchMarkKey)
     }
     
     /// 체크리스트(TableView)를 위해 goalData를 정렬하는 함수

--- a/Milestone/Milestone/Screens/FillBox/View/FillBoxViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/FillBoxViewController.swift
@@ -48,6 +48,10 @@ class FillBoxViewController: BaseViewController {
             $0.guideLabel.text = "목표를 클릭하여 세부 목표를 설정해보세요!"
         }
     
+    // MARK: - Properties
+    
+    var bubbleKey = UserDefaultsKeyStyle.bubbleInFillBox.rawValue
+    
     // MARK: - Life Cycle
     
     override func viewDidLoad() {
@@ -85,7 +89,8 @@ class FillBoxViewController: BaseViewController {
     
     /// 처음이 맞는지 확인 -> 맞으면 말풍선 뷰 띄우기
     private func checkFirstFillBox() {
-        if UserDefaults.standard.string(forKey: "showBubble") == nil {
+        if !UserDefaults.standard.bool(forKey: bubbleKey) { // 처음이면 무조건 false 반환함
+            UserDefaults.standard.set(true, forKey: bubbleKey)
             addBubbleView()
         }
     }
@@ -100,7 +105,6 @@ class FillBoxViewController: BaseViewController {
             make.width.equalTo(268)
             make.height.equalTo(45)
         }
-        UserDefaults.standard.set("", forKey: "showBubble")
     }
     
     private func didScrollTableView() {


### PR DESCRIPTION
## 상세 내용
- #86 
- 채움함의 말풍선 뷰, 완료함의 말풍선 뷰를 띄울 때에 사용한 `UserDefaults`의 `key` 값으로 `enum`을 적용하여 코드를 개선하였습니다.
1. `UserDefaultsKeyStyle`에 `case`로 `bubbleInFillBox`, `bubbleInCompletionBox` 2개를 추가하였습니다.
2. 추가적으로 `UserDefaults` 값을 `string` 타입으로 저장하던 코드를 `bool` 타입으로 저장하는 코드로 변경하였습니다. (코치 마크 뷰, 채움함 말풍선 뷰, 완료함 말풍선 뷰 모두 적용)
- `string`보다 `bool`이 더 간단하고 직관적이라고 생각했기 때문입니다.
- `UserDefaults.standard.bool(forKey:)`는 `key`에 해당하는 값이 없으면 `false`를 리턴한다는 점을 활용하여 `UserDefaults.standard.bool(forKey:)`가 `false`일 때에만 어떤 뷰를 띄워주고 그 이후에는 `set`으로 `true`를 저장하는 로직을 사용했습니다.

## 기타
- 2번은 이슈와 조금 다른 내용일 수도 있지만 이슈 또 파기에도 좀 그렇고 `UserDefaults`의 사용성을 개선한다는 측면에서 그냥 이 이슈 안에서 해결했습니다!
- 앞으로 새 `UserDefaults`를 사용해야 할 일이 생겼을 때에는 `key` 값은 `UserDefaultsKeyStyle`에 추가해 주시면 됩니다!

## 셀프 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩 컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 오른쪽의 Development에서 이슈와 연결하였는가?
