### PR TITLE
[#110] 채움함 상위 목표 목록 조회 API 연동

### DIFF
--- a/Milestone/Milestone.xcodeproj/project.pbxproj
+++ b/Milestone/Milestone.xcodeproj/project.pbxproj
@@ -218,7 +218,7 @@
 		C90DC9862A88F0B100241B7C /* UITextField+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90DC9852A88F0B100241B7C /* UITextField+.swift */; };
 		C90DC9882A891A8500241B7C /* OnboardingViewControllerLast.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90DC9872A891A8500241B7C /* OnboardingViewControllerLast.swift */; };
 		C90DC98A2A8922D300241B7C /* NSMutableAttributedString+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90DC9892A8922D300241B7C /* NSMutableAttributedString+.swift */; };
-		C95A3C9B2A94D08D0028B4ED /* CompletedGoal.swift in Sources */ = {isa = PBXBuildFile; fileRef = C95A3C9A2A94D08D0028B4ED /* CompletedGoal.swift */; };
+		C95A3C9B2A94D08D0028B4ED /* ParentGoal.swift in Sources */ = {isa = PBXBuildFile; fileRef = C95A3C9A2A94D08D0028B4ED /* ParentGoal.swift */; };
 		C95A3C9F2A94E0AC0028B4ED /* CompletionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C95A3C9E2A94E0AC0028B4ED /* CompletionHeaderView.swift */; };
 		C95A3CA12A94EB580028B4ED /* RewardToImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C95A3CA02A94EB580028B4ED /* RewardToImage.swift */; };
 		C9798ACA2A939F9600B5CC4A /* BindableViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9798AC92A939F9600B5CC4A /* BindableViewModel.swift */; };
@@ -369,7 +369,7 @@
 		C90DC9852A88F0B100241B7C /* UITextField+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+.swift"; sourceTree = "<group>"; };
 		C90DC9872A891A8500241B7C /* OnboardingViewControllerLast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewControllerLast.swift; sourceTree = "<group>"; };
 		C90DC9892A8922D300241B7C /* NSMutableAttributedString+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMutableAttributedString+.swift"; sourceTree = "<group>"; };
-		C95A3C9A2A94D08D0028B4ED /* CompletedGoal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletedGoal.swift; sourceTree = "<group>"; };
+		C95A3C9A2A94D08D0028B4ED /* ParentGoal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentGoal.swift; sourceTree = "<group>"; };
 		C95A3C9E2A94E0AC0028B4ED /* CompletionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionHeaderView.swift; sourceTree = "<group>"; };
 		C95A3CA02A94EB580028B4ED /* RewardToImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardToImage.swift; sourceTree = "<group>"; };
 		C9798AC92A939F9600B5CC4A /* BindableViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BindableViewModel.swift; path = Foundation/BindableViewModel.swift; sourceTree = "<group>"; };
@@ -891,7 +891,7 @@
 				C9B2CE4A2A92F95E006289A8 /* DetailGoal.swift */,
 				A282DA552A94C20300A0D0BF /* DetailGoalInfo.swift */,
 				C9040FCB2A93B64A00270E94 /* Token.swift */,
-				C95A3C9A2A94D08D0028B4ED /* CompletedGoal.swift */,
+				C95A3C9A2A94D08D0028B4ED /* ParentGoal.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1120,7 +1120,7 @@
 				88216FC02A85328900FE3A77 /* LoginViewController.swift in Sources */,
 				A2C98F062A8B6122009B5579 /* EnterGoalTitleView.swift in Sources */,
 				A2B969872A85875A00C4903F /* ParentGoalTableViewCell.swift in Sources */,
-				C95A3C9B2A94D08D0028B4ED /* CompletedGoal.swift in Sources */,
+				C95A3C9B2A94D08D0028B4ED /* ParentGoal.swift in Sources */,
 				C9B2CE172A8F5267006289A8 /* APIRouter.swift in Sources */,
 				A2C98F162A8BA6F0009B5579 /* RoundedButton.swift in Sources */,
 				A289D9462A91246C005B7F00 /* DayStyle.swift in Sources */,

--- a/Milestone/Milestone/Core/Services/ServicesGoalList.swift
+++ b/Milestone/Milestone/Core/Services/ServicesGoalList.swift
@@ -10,11 +10,11 @@ import Foundation
 import RxSwift
 
 protocol ServicesGoalList: Service {
-    func requestAllGoals<T>(goalStatusParameter: GoalStatusParameter) -> Observable<Result<BaseModel<GoalResponse<T>>, APIError>>
+    func requestAllGoals(goalStatusParameter: GoalStatusParameter) -> Observable<Result<BaseModel<GoalResponse>, APIError>>
 }
 
 extension ServicesGoalList {
-    func requestAllGoals<T>(goalStatusParameter: GoalStatusParameter) -> Observable<Result<BaseModel<GoalResponse<T>>, APIError>> {
+    func requestAllGoals(goalStatusParameter: GoalStatusParameter) -> Observable<Result<BaseModel<GoalResponse>, APIError>> {
         return apiSession.request(.requestAllGoals(goalStatus: goalStatusParameter))
     }
 }

--- a/Milestone/Milestone/Model/Goal.swift
+++ b/Milestone/Milestone/Model/Goal.swift
@@ -8,10 +8,12 @@
 import Foundation
 import RxDataSources
 
-struct GoalResponse<T: Codable>: Codable {
-    let contents: [T]
+struct GoalResponse: Codable {
+    let contents: [ParentGoal]
     let next: Bool
 }
+
+// TODO: - 상위 목표 수정 req 모델
 
 struct Goal: Codable, IdentifiableType, Equatable {
     let identity: Int

--- a/Milestone/Milestone/Model/ParentGoal.swift
+++ b/Milestone/Milestone/Model/ParentGoal.swift
@@ -11,15 +11,15 @@ import RxDataSources
 // MARK: - 상위 목표 모델 (채움함, 완료함, 보관함에 사용)
 
 struct ParentGoal: Codable, IdentifiableType, Equatable {
-    let identity: Int
-    let reward: String
-    let endDate: String
-    let startDate: String
-    let title: String
-    let completedDetailGoalCnt: Int
-    let entireDetailGoalCnt: Int
-    let hasRetrospect: Bool
-    let dDay: Int
+    let identity: Int?
+    let reward: String?
+    let endDate: String?
+    let startDate: String?
+    let title: String?
+    let completedDetailGoalCnt: Int?
+    let entireDetailGoalCnt: Int?
+    let hasRetrospect: Bool?
+    let dDay: Int?
     
     enum CodingKeys: String, CodingKey {
         case identity = "goalId"

--- a/Milestone/Milestone/Model/ParentGoal.swift
+++ b/Milestone/Milestone/Model/ParentGoal.swift
@@ -8,7 +8,9 @@
 import Foundation
 import RxDataSources
 
-struct CompletedGoal: Codable, IdentifiableType, Equatable {
+// MARK: - 상위 목표 모델 (채움함, 완료함, 보관함에 사용)
+
+struct ParentGoal: Codable, IdentifiableType, Equatable {
     let identity: Int
     let reward: String
     let endDate: String

--- a/Milestone/Milestone/Model/ParentGoal.swift
+++ b/Milestone/Milestone/Model/ParentGoal.swift
@@ -11,15 +11,15 @@ import RxDataSources
 // MARK: - 상위 목표 모델 (채움함, 완료함, 보관함에 사용)
 
 struct ParentGoal: Codable, IdentifiableType, Equatable {
-    let identity: Int?
+    let identity: Int
     let reward: String?
-    let endDate: String?
-    let startDate: String?
-    let title: String?
-    let completedDetailGoalCnt: Int?
-    let entireDetailGoalCnt: Int?
-    let hasRetrospect: Bool?
-    let dDay: Int?
+    let endDate: String
+    let startDate: String
+    let title: String
+    let completedDetailGoalCnt: Int
+    let entireDetailGoalCnt: Int
+    let hasRetrospect: Bool
+    let dDay: Int
     
     enum CodingKeys: String, CodingKey {
         case identity = "goalId"

--- a/Milestone/Milestone/Screens/CompletionBox/View/CompletionBoxViewController.swift
+++ b/Milestone/Milestone/Screens/CompletionBox/View/CompletionBoxViewController.swift
@@ -105,19 +105,19 @@ class CompletionBoxViewController: BaseViewController, ViewModelBindableType {
     override func configUI() {
         view.backgroundColor = .gray01
         
-        bindViewModel()
+//        bindViewModel()
     }
     
     func bindViewModel() {
         viewModel.goalData
             .bind(to: tableView.rx.items(cellIdentifier: CompletionTableViewCell.identifier, cellType: CompletionTableViewCell.self)) { [unowned self] row, element, cell in
-                let startDate = dateFormatter.date(from: element.startDate)!
-                let endDate = dateFormatter.date(from: element.endDate)!
+                let startDate = dateFormatter.date(from: element.startDate!)!
+                let endDate = dateFormatter.date(from: element.endDate!)!
                 cell.dateLabel.text = dateFormatter.string(from: startDate) + " - " + dateFormatter.string(from: endDate)
                 cell.label.text = element.title
-                cell.completionImageView.image = UIImage(named: RewardToImage(rawValue: element.reward)!.rawValue)
+                cell.completionImageView.image = UIImage(named: RewardToImage(rawValue: element.reward!)!.rawValue)
                 
-                if element.hasRetrospect {
+                if element.hasRetrospect! {
                     cell.button.buttonComponentStyle = .secondary_m_line
                     cell.button.buttonState = .original
                 } else {

--- a/Milestone/Milestone/Screens/CompletionBox/View/CompletionBoxViewController.swift
+++ b/Milestone/Milestone/Screens/CompletionBox/View/CompletionBoxViewController.swift
@@ -111,13 +111,13 @@ class CompletionBoxViewController: BaseViewController, ViewModelBindableType {
     func bindViewModel() {
         viewModel.goalData
             .bind(to: tableView.rx.items(cellIdentifier: CompletionTableViewCell.identifier, cellType: CompletionTableViewCell.self)) { [unowned self] row, element, cell in
-                let startDate = dateFormatter.date(from: element.startDate!)!
-                let endDate = dateFormatter.date(from: element.endDate!)!
+                let startDate = dateFormatter.date(from: element.startDate)!
+                let endDate = dateFormatter.date(from: element.endDate)!
                 cell.dateLabel.text = dateFormatter.string(from: startDate) + " - " + dateFormatter.string(from: endDate)
                 cell.label.text = element.title
-                cell.completionImageView.image = UIImage(named: RewardToImage(rawValue: element.reward!)!.rawValue)
+                cell.completionImageView.image = UIImage(named: RewardToImage(rawValue: element.reward ?? "BLUE_JEWEL_1")!.rawValue)
                 
-                if element.hasRetrospect! {
+                if element.hasRetrospect {
                     cell.button.buttonComponentStyle = .secondary_m_line
                     cell.button.buttonState = .original
                 } else {

--- a/Milestone/Milestone/Screens/CompletionBox/View/CompletionReviewViewController.swift
+++ b/Milestone/Milestone/Screens/CompletionBox/View/CompletionReviewViewController.swift
@@ -210,8 +210,8 @@ class CompletionReviewViewController: BaseViewController, ViewModelBindableType 
         
         viewModel.retrieveGoalDataAtIndex(index: goalIndex)
             .map { [unowned self] goal -> String in
-                let startDate = dateFormatter.date(from: goal.startDate!)!
-                let endDate = dateFormatter.date(from: goal.endDate!)!
+                let startDate = dateFormatter.date(from: goal.startDate)!
+                let endDate = dateFormatter.date(from: goal.endDate)!
                 return "\(dateFormatter.string(from: startDate)) - \(dateFormatter.string(from: endDate))"
             }
             .bind(to: dateLabel.rx.text)

--- a/Milestone/Milestone/Screens/CompletionBox/View/CompletionReviewViewController.swift
+++ b/Milestone/Milestone/Screens/CompletionBox/View/CompletionReviewViewController.swift
@@ -210,8 +210,8 @@ class CompletionReviewViewController: BaseViewController, ViewModelBindableType 
         
         viewModel.retrieveGoalDataAtIndex(index: goalIndex)
             .map { [unowned self] goal -> String in
-                let startDate = dateFormatter.date(from: goal.startDate)!
-                let endDate = dateFormatter.date(from: goal.endDate)!
+                let startDate = dateFormatter.date(from: goal.startDate!)!
+                let endDate = dateFormatter.date(from: goal.endDate!)!
                 return "\(dateFormatter.string(from: startDate)) - \(dateFormatter.string(from: endDate))"
             }
             .bind(to: dateLabel.rx.text)

--- a/Milestone/Milestone/Screens/CompletionBox/ViewModel/CompletionViewModel.swift
+++ b/Milestone/Milestone/Screens/CompletionBox/ViewModel/CompletionViewModel.swift
@@ -18,11 +18,11 @@ class CompletionViewModel: BindableViewModel {
     var bag = DisposeBag()
     
     // MARK: - Output
-    var goalResponse: Observable<Result<BaseModel<GoalResponse<CompletedGoal>>, APIError>> {
+    var goalResponse: Observable<Result<BaseModel<GoalResponse>, APIError>> {
         requestAllGoals(goalStatusParameter: .complete)
     }
     
-    var goalData = BehaviorRelay<[CompletedGoal]>(value: [])
+    var goalData = BehaviorRelay<[ParentGoal]>(value: [])
     var goalDataCount = PublishRelay<Int>()
     
     deinit {
@@ -45,7 +45,7 @@ extension CompletionViewModel: ServicesGoalList {
             .disposed(by: bag)
     }
     
-    func retrieveGoalDataAtIndex(index: Int) -> Observable<CompletedGoal> {
+    func retrieveGoalDataAtIndex(index: Int) -> Observable<ParentGoal> {
         return goalData.map { $0[index] }
     }
 }

--- a/Milestone/Milestone/Screens/FillBox/View/FillBoxViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/FillBoxViewController.swift
@@ -93,7 +93,7 @@ class FillBoxViewController: BaseViewController, ViewModelBindableType {
                 cell.goalAchievementRateView.completedCount = CGFloat(goal.completedDetailGoalCnt ?? 0)
                 cell.goalAchievementRateView.totalCount = CGFloat(goal.entireDetailGoalCnt ?? 0)
                 cell.titleLabel.text = goal.title
-                cell.termLabel.text = "\(goal.startDate!) - \(goal.endDate!)"
+                cell.termLabel.text = "\(goal.startDate) - \(goal.endDate)"
             }
             .disposed(by: disposeBag)
     }

--- a/Milestone/Milestone/Screens/FillBox/View/FillBoxViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/FillBoxViewController.swift
@@ -85,13 +85,17 @@ class FillBoxViewController: BaseViewController, ViewModelBindableType {
     }
     
     func bindViewModel() {
-        viewModel.goalObservable
+        // 상위 목표 조회 API 호출
+        viewModel.retrieveGoalData()
+        
+        viewModel.progressGoals
             .bind(to: parentGoalTableView.rx.items(cellIdentifier: ParentGoalTableViewCell.identifier, cellType: ParentGoalTableViewCell.self)) { _, goal, cell in
+                cell.goalAchievementRateView.completedCount = CGFloat(goal.completedDetailGoalCnt ?? 0)
+                cell.goalAchievementRateView.totalCount = CGFloat(goal.entireDetailGoalCnt ?? 0)
                 cell.titleLabel.text = goal.title
-                cell.termLabel.text = "\(goal.startDate) - \(goal.endDate)"
+                cell.termLabel.text = "\(goal.startDate!) - \(goal.endDate!)"
             }
             .disposed(by: disposeBag)
-        Logger.debugDescription("bye")
     }
     
     /// 처음이 맞는지 확인 -> 맞으면 말풍선 뷰 띄우기

--- a/Milestone/Milestone/Screens/FillBox/ViewModel/FillBoxViewModel.swift
+++ b/Milestone/Milestone/Screens/FillBox/ViewModel/FillBoxViewModel.swift
@@ -17,29 +17,29 @@ class FillBoxViewModel: BindableViewModel {
     var apiSession: APIService = APISession()
     var bag = DisposeBag()
     
-    // MARK: - Properties
+    // MARK: - Output
     
-    private var goalList = [
-        Goal(identity: 0, title: "하이1", startDate: "2023.08.08", endDate: "2023.08.26", reminderEnabled: true),
-        Goal(identity: 0, title: "하이2", startDate: "2023.08.08", endDate: "2023.08.26", reminderEnabled: true),
-        Goal(identity: 0, title: "하이3", startDate: "2023.08.08", endDate: "2023.08.26", reminderEnabled: true),
-        Goal(identity: 0, title: "하이4", startDate: "2023.08.08", endDate: "2023.08.26", reminderEnabled: true),
-        Goal(identity: 0, title: "하이5", startDate: "2023.08.08", endDate: "2023.08.26", reminderEnabled: true),
-        Goal(identity: 0, title: "하이6", startDate: "2023.08.08", endDate: "2023.08.26", reminderEnabled: true),
-        Goal(identity: 0, title: "하이7", startDate: "2023.08.08", endDate: "2023.08.26", reminderEnabled: true),
-        Goal(identity: 0, title: "하이8", startDate: "2023.08.08", endDate: "2023.08.26", reminderEnabled: true),
-        Goal(identity: 0, title: "하이9", startDate: "2023.08.08", endDate: "2023.08.26", reminderEnabled: true),
-        Goal(identity: 0, title: "하이10", startDate: "2023.08.08", endDate: "2023.08.26", reminderEnabled: true),
-        Goal(identity: 0, title: "하이11", startDate: "2023.08.08", endDate: "2023.08.26", reminderEnabled: true),
-        Goal(identity: 0, title: "하이12", startDate: "2023.08.08", endDate: "2023.08.26", reminderEnabled: true)
-    ]
-    private lazy var store = BehaviorSubject<[Goal]>(value: goalList)
-    
-    var goalObservable: Observable<[Goal]> {
-        return store
+    var goalResponse: Observable<Result<BaseModel<GoalResponse>, APIError>> {
+        requestAllGoals(goalStatusParameter: .process)
     }
+    var progressGoals = BehaviorRelay<[ParentGoal]>(value: [])
     
     deinit {
         bag = DisposeBag()
+    }
+}
+
+extension FillBoxViewModel: ServicesGoalList {
+    func retrieveGoalData() {
+        goalResponse
+            .subscribe(onNext: { [unowned self] result in
+                switch result {
+                case .success(let response):
+                    progressGoals.accept(response.data.contents)
+                case .failure(let error):
+                    print(error)
+                }
+            })
+            .disposed(by: bag)
     }
 }

--- a/Milestone/Milestone/Screens/Onboarding/ViewModel/OnboardingViewModel.swift
+++ b/Milestone/Milestone/Screens/Onboarding/ViewModel/OnboardingViewModel.swift
@@ -63,7 +63,7 @@ class OnboardingViewModel: BindableViewModel {
         Observable.merge(mergedObservable)
             .subscribe(onCompleted: { [weak self] in
                 guard let self = self else { return }
-                loginCoordinator?.coordinateToOnboarding()
+                self.loginCoordinator?.coordinateToOnboarding()
             })
             .disposed(by: bag)
     }
@@ -102,7 +102,7 @@ class OnboardingViewModel: BindableViewModel {
         Observable.merge(mergedObservable)
             .subscribe(onCompleted: { [weak self] in
                 guard let self = self else { return }
-                loginCoordinator?.coordinateToOnboarding()
+                self.loginCoordinator?.coordinateToOnboarding()
             })
             .disposed(by: bag)
     }


### PR DESCRIPTION
## 상세 내용
- #110 
- 상위 목표 조회 API 연동
- 채움함 메인 화면 상위 목표 목록에 데이터 바인딩

## 기타
- `CompleteGoal` -> `ParentGoal`로 이름을 변경하였습니다.
- `ParentGoal`의 `reward` 프로퍼티는 `null`로도 올 수 있기 때문에 `Optional` 처리하였습니다.

## 셀프 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩 컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 오른쪽의 Development에서 이슈와 연결하였는가?
