### PR TITLE
[#111] 상위 목표 상태별 개수 조회 API 연동 및 데이터 바인딩

### DIFF
--- a/Milestone/Milestone.xcodeproj/project.pbxproj
+++ b/Milestone/Milestone.xcodeproj/project.pbxproj
@@ -888,10 +888,10 @@
 			isa = PBXGroup;
 			children = (
 				C9B2CE482A92F957006289A8 /* Goal.swift */,
+				C95A3C9A2A94D08D0028B4ED /* ParentGoal.swift */,
 				C9B2CE4A2A92F95E006289A8 /* DetailGoal.swift */,
 				A282DA552A94C20300A0D0BF /* DetailGoalInfo.swift */,
 				C9040FCB2A93B64A00270E94 /* Token.swift */,
-				C95A3C9A2A94D08D0028B4ED /* ParentGoal.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";

--- a/Milestone/Milestone/Core/Services/ServicesGoalList.swift
+++ b/Milestone/Milestone/Core/Services/ServicesGoalList.swift
@@ -11,10 +11,14 @@ import RxSwift
 
 protocol ServicesGoalList: Service {
     func requestAllGoals(goalStatusParameter: GoalStatusParameter) -> Observable<Result<BaseModel<GoalResponse>, APIError>>
+    func requestGoalCountByStatus() -> Observable<Result<BaseModel<ParentGoalCount>, APIError>>
 }
 
 extension ServicesGoalList {
     func requestAllGoals(goalStatusParameter: GoalStatusParameter) -> Observable<Result<BaseModel<GoalResponse>, APIError>> {
         return apiSession.request(.requestAllGoals(goalStatus: goalStatusParameter))
+    }
+    func requestGoalCountByStatus() -> Observable<Result<BaseModel<ParentGoalCount>, APIError>> {
+        return apiSession.request(.requestGoalCountByStatus)
     }
 }

--- a/Milestone/Milestone/Model/ParentGoal.swift
+++ b/Milestone/Milestone/Model/ParentGoal.swift
@@ -33,3 +33,15 @@ struct ParentGoal: Codable, IdentifiableType, Equatable {
         case dDay = "dDay"
     }
 }
+
+// MARK: - 상위 목표 개수 모델
+
+struct ParentGoalCount: Codable {
+    var counts: Count
+}
+
+struct Count: Codable {
+    var STORE: Int
+    var PROCESS: Int
+    var COMPLETE: Int
+}

--- a/Milestone/Milestone/Screens/FillBox/View/FillBoxViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/FillBoxViewController.swift
@@ -87,14 +87,22 @@ class FillBoxViewController: BaseViewController, ViewModelBindableType {
     func bindViewModel() {
         // 상위 목표 조회 API 호출
         viewModel.retrieveParentGoalList()
-        
         viewModel.progressGoals
             .bind(to: parentGoalTableView.rx.items(cellIdentifier: ParentGoalTableViewCell.identifier, cellType: ParentGoalTableViewCell.self)) { _, goal, cell in
-                cell.goalAchievementRateView.completedCount = CGFloat(goal.completedDetailGoalCnt ?? 0)
-                cell.goalAchievementRateView.totalCount = CGFloat(goal.entireDetailGoalCnt ?? 0)
+                cell.goalAchievementRateView.completedCount = CGFloat(goal.completedDetailGoalCnt)
+                cell.goalAchievementRateView.totalCount = CGFloat(goal.entireDetailGoalCnt)
                 cell.titleLabel.text = goal.title
                 cell.termLabel.text = "\(goal.startDate) - \(goal.endDate)"
             }
+            .disposed(by: disposeBag)
+        
+        // 상위 목표 상태별 개수 조회 API 호출
+        viewModel.retrieveGoalCountByStatus()
+        viewModel.progressGoalCount
+            .bind(to: parentGoalHeaderView.ongoingGoalView.goalNumberLabel.rx.text)
+            .disposed(by: disposeBag)
+        viewModel.completedGoalCount
+            .bind(to: parentGoalHeaderView.completedGoalView.goalNumberLabel.rx.text)
             .disposed(by: disposeBag)
     }
     

--- a/Milestone/Milestone/Screens/FillBox/View/FillBoxViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/FillBoxViewController.swift
@@ -86,7 +86,7 @@ class FillBoxViewController: BaseViewController, ViewModelBindableType {
     
     func bindViewModel() {
         // 상위 목표 조회 API 호출
-        viewModel.retrieveGoalData()
+        viewModel.retrieveParentGoalList()
         
         viewModel.progressGoals
             .bind(to: parentGoalTableView.rx.items(cellIdentifier: ParentGoalTableViewCell.identifier, cellType: ParentGoalTableViewCell.self)) { _, goal, cell in

--- a/Milestone/Milestone/Screens/FillBox/ViewModel/FillBoxViewModel.swift
+++ b/Milestone/Milestone/Screens/FillBox/ViewModel/FillBoxViewModel.swift
@@ -10,7 +10,7 @@ import UIKit
 import RxCocoa
 import RxSwift
 
-class FillBoxViewModel: BindableViewModel {
+class FillBoxViewModel: BindableViewModel, ServicesGoalList {
     
     // MARK: - BindableViewModel Properties
     
@@ -19,9 +19,14 @@ class FillBoxViewModel: BindableViewModel {
     
     // MARK: - Output
     
-    var goalResponse: Observable<Result<BaseModel<GoalResponse>, APIError>> {
+    var goalCountByStatusResponse: Observable<Result<BaseModel<ParentGoalCount>, APIError>> {
+        requestGoalCountByStatus()
+    }
+    var parentGoalListResponse: Observable<Result<BaseModel<GoalResponse>, APIError>> {
         requestAllGoals(goalStatusParameter: .process)
     }
+    
+    var goalCount = BehaviorRelay<Count>(value: Count(STORE: 0, PROCESS: 0, COMPLETE: 0))
     var progressGoals = BehaviorRelay<[ParentGoal]>(value: [])
     
     deinit {
@@ -29,15 +34,29 @@ class FillBoxViewModel: BindableViewModel {
     }
 }
 
-extension FillBoxViewModel: ServicesGoalList {
-    func retrieveGoalData() {
-        goalResponse
+extension FillBoxViewModel {
+    
+    func retrieveGoalCountByStatus() {
+        goalCountByStatusResponse
+            .subscribe(onNext: { [unowned self] result in
+                switch result {
+                case .success(let response):
+                    goalCount.accept(response.data.counts)
+                case .failure(let error):
+                    Logger.debugDescription(error)
+                }
+            })
+            .disposed(by: bag)
+    }
+    
+    func retrieveParentGoalList() {
+        parentGoalListResponse
             .subscribe(onNext: { [unowned self] result in
                 switch result {
                 case .success(let response):
                     progressGoals.accept(response.data.contents)
                 case .failure(let error):
-                    print(error)
+                    Logger.debugDescription(error)
                 }
             })
             .disposed(by: bag)

--- a/Milestone/Milestone/Screens/FillBox/ViewModel/FillBoxViewModel.swift
+++ b/Milestone/Milestone/Screens/FillBox/ViewModel/FillBoxViewModel.swift
@@ -26,7 +26,8 @@ class FillBoxViewModel: BindableViewModel, ServicesGoalList {
         requestAllGoals(goalStatusParameter: .process)
     }
     
-    var goalCount = BehaviorRelay<Count>(value: Count(STORE: 0, PROCESS: 0, COMPLETE: 0))
+    var progressGoalCount = BehaviorRelay<String>(value: "0")
+    var completedGoalCount = BehaviorRelay<String>(value: "0")
     var progressGoals = BehaviorRelay<[ParentGoal]>(value: [])
     
     deinit {
@@ -41,7 +42,8 @@ extension FillBoxViewModel {
             .subscribe(onNext: { [unowned self] result in
                 switch result {
                 case .success(let response):
-                    goalCount.accept(response.data.counts)
+                    progressGoalCount.accept(String(response.data.counts.PROCESS))
+                    completedGoalCount.accept(String(response.data.counts.COMPLETE))
                 case .failure(let error):
                     Logger.debugDescription(error)
                 }


### PR DESCRIPTION
## 상세 내용
- #111 
- 상위 목표 상태별 개수 response를 받을 모델 추가 (`ParentGoalCount`, `Count`) -> 현재 일단 상위 목표 관련 데이터니까 `ParentGoal` 파일에 넣어두긴 했는데 나중에 모델 관련한 파일들 한번 정리하는 게 좋을 듯합니다.
- 상위 목표 상태별 개수 조회 API 연동 -> `ServicesGoalList`에 `requestGoalCountByStatus` 함수 추가
- 데이터 바인딩 

## 기타
- 응답으로 받은 `PROCESS`(진행 중 목표 개수)와 `COMPLETE`(완료한 목표 개수)만 사용했어요!
- 보관함 화면에 있는 보관함 목표 개수 label은 현재 완료함 코드처럼 보관함의 상위 목표 목록을 조회해서 해당 배열의 `count`로 설정해주면 될 것 같아서 그렇게 하려고 합니다!
- `STORE` 값은 사용하지 않은 건데 혹시나 나중에 필요할 수도 있을 것 같아서 일단 두려고 합니다. 개발이 다 완료될 때까지 사용할 일이 없다면 서버한테 말할 생각입니다!

## 셀프 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩 컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 오른쪽의 Development에서 이슈와 연결하였는가?
