### PR TITLE
[#116] 상위 목표 생성 API 연동

### DIFF
--- a/Milestone/Milestone.xcodeproj/project.pbxproj
+++ b/Milestone/Milestone.xcodeproj/project.pbxproj
@@ -34,6 +34,9 @@
 		A25988F62A965E9700C6BDE0 /* AddParentGoalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25988F52A965E9700C6BDE0 /* AddParentGoalViewModel.swift */; };
 		A25988F72A965E9700C6BDE0 /* AddParentGoalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25988F52A965E9700C6BDE0 /* AddParentGoalViewModel.swift */; };
 		A25988F82A965E9700C6BDE0 /* AddParentGoalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25988F52A965E9700C6BDE0 /* AddParentGoalViewModel.swift */; };
+		A25988FA2A967C3000C6BDE0 /* UpdateParentGoalListDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25988F92A967C3000C6BDE0 /* UpdateParentGoalListDelegate.swift */; };
+		A25988FB2A967C3000C6BDE0 /* UpdateParentGoalListDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25988F92A967C3000C6BDE0 /* UpdateParentGoalListDelegate.swift */; };
+		A25988FC2A967C3000C6BDE0 /* UpdateParentGoalListDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25988F92A967C3000C6BDE0 /* UpdateParentGoalListDelegate.swift */; };
 		A265090C2A8D458300E9A2D7 /* BubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A265090B2A8D458300E9A2D7 /* BubbleView.swift */; };
 		A26509102A8D604100E9A2D7 /* CouchMarkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A265090F2A8D604100E9A2D7 /* CouchMarkViewController.swift */; };
 		A26509112A8D604100E9A2D7 /* CouchMarkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A265090F2A8D604100E9A2D7 /* CouchMarkViewController.swift */; };
@@ -298,6 +301,7 @@
 		A23E8BA12A9013610051D135 /* AskOneOfTwoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AskOneOfTwoView.swift; sourceTree = "<group>"; };
 		A252C4B32A92B5AB0067B89C /* ParentGoal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentGoal.swift; sourceTree = "<group>"; };
 		A25988F52A965E9700C6BDE0 /* AddParentGoalViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddParentGoalViewModel.swift; sourceTree = "<group>"; };
+		A25988F92A967C3000C6BDE0 /* UpdateParentGoalListDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateParentGoalListDelegate.swift; sourceTree = "<group>"; };
 		A265090B2A8D458300E9A2D7 /* BubbleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BubbleView.swift; sourceTree = "<group>"; };
 		A265090F2A8D604100E9A2D7 /* CouchMarkViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouchMarkViewController.swift; sourceTree = "<group>"; };
 		A26509132A8DE1BA00E9A2D7 /* AddDetailGoalStoneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddDetailGoalStoneView.swift; sourceTree = "<group>"; };
@@ -612,6 +616,7 @@
 			children = (
 				A289D95B2A9133C7005B7F00 /* PresentDelegate.swift */,
 				A289D95F2A913400005B7F00 /* UpdateButtonStateDelegate.swift */,
+				A25988F92A967C3000C6BDE0 /* UpdateParentGoalListDelegate.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -1215,6 +1220,7 @@
 				C9798ACA2A939F9600B5CC4A /* BindableViewModel.swift in Sources */,
 				A2B20D9A2A7ED40D001ED73C /* Logger.swift in Sources */,
 				A2B20D592A7E4E5C001ED73C /* UIFont+.swift in Sources */,
+				A25988FA2A967C3000C6BDE0 /* UpdateParentGoalListDelegate.swift in Sources */,
 				C9B2CE152A8F514A006289A8 /* APIService.swift in Sources */,
 				C9B2CDD62A8A77F1006289A8 /* CompletionViewModel.swift in Sources */,
 				C9B2CDFF2A8DE365006289A8 /* CompleteView.swift in Sources */,
@@ -1263,6 +1269,7 @@
 				A2FA592A2A7FD3BA006ACA2E /* UITableView+.swift in Sources */,
 				A2C98F032A8B6117009B5579 /* AddParentGoalViewController.swift in Sources */,
 				A25988F72A965E9700C6BDE0 /* AddParentGoalViewModel.swift in Sources */,
+				A25988FB2A967C3000C6BDE0 /* UpdateParentGoalListDelegate.swift in Sources */,
 				A2B20D952A7ED174001ED73C /* UIImage+.swift in Sources */,
 				A2B20D912A7ED14C001ED73C /* ImageLiteral.swift in Sources */,
 				A28EDA1A2A879565001A021A /* DetailParentViewController.swift in Sources */,
@@ -1320,6 +1327,7 @@
 				A2248E852A8818AD00EB995A /* DetailGoalTableViewCell.swift in Sources */,
 				A289D9662A922950005B7F00 /* RecommendGoalViewController.swift in Sources */,
 				A2D304CB2A856B6B00A5BA92 /* StorageBoxViewController.swift in Sources */,
+				A25988FC2A967C3000C6BDE0 /* UpdateParentGoalListDelegate.swift in Sources */,
 				A28EDA1B2A879565001A021A /* DetailParentViewController.swift in Sources */,
 				A2FA59232A7FD2EC006ACA2E /* BaseTableViewCell.swift in Sources */,
 				A252C4B62A92B5AB0067B89C /* ParentGoal.swift in Sources */,

--- a/Milestone/Milestone.xcodeproj/project.pbxproj
+++ b/Milestone/Milestone.xcodeproj/project.pbxproj
@@ -31,6 +31,9 @@
 		A23E8BA22A9013610051D135 /* AskOneOfTwoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23E8BA12A9013610051D135 /* AskOneOfTwoView.swift */; };
 		A252C4B52A92B5AB0067B89C /* ParentGoal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A252C4B32A92B5AB0067B89C /* ParentGoal.swift */; };
 		A252C4B62A92B5AB0067B89C /* ParentGoal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A252C4B32A92B5AB0067B89C /* ParentGoal.swift */; };
+		A25988F62A965E9700C6BDE0 /* AddParentGoalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25988F52A965E9700C6BDE0 /* AddParentGoalViewModel.swift */; };
+		A25988F72A965E9700C6BDE0 /* AddParentGoalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25988F52A965E9700C6BDE0 /* AddParentGoalViewModel.swift */; };
+		A25988F82A965E9700C6BDE0 /* AddParentGoalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25988F52A965E9700C6BDE0 /* AddParentGoalViewModel.swift */; };
 		A265090C2A8D458300E9A2D7 /* BubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A265090B2A8D458300E9A2D7 /* BubbleView.swift */; };
 		A26509102A8D604100E9A2D7 /* CouchMarkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A265090F2A8D604100E9A2D7 /* CouchMarkViewController.swift */; };
 		A26509112A8D604100E9A2D7 /* CouchMarkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A265090F2A8D604100E9A2D7 /* CouchMarkViewController.swift */; };
@@ -294,6 +297,7 @@
 		A23E8B9F2A900EEC0051D135 /* DeleteGoalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteGoalViewController.swift; sourceTree = "<group>"; };
 		A23E8BA12A9013610051D135 /* AskOneOfTwoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AskOneOfTwoView.swift; sourceTree = "<group>"; };
 		A252C4B32A92B5AB0067B89C /* ParentGoal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentGoal.swift; sourceTree = "<group>"; };
+		A25988F52A965E9700C6BDE0 /* AddParentGoalViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddParentGoalViewModel.swift; sourceTree = "<group>"; };
 		A265090B2A8D458300E9A2D7 /* BubbleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BubbleView.swift; sourceTree = "<group>"; };
 		A265090F2A8D604100E9A2D7 /* CouchMarkViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouchMarkViewController.swift; sourceTree = "<group>"; };
 		A26509132A8DE1BA00E9A2D7 /* AddDetailGoalStoneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddDetailGoalStoneView.swift; sourceTree = "<group>"; };
@@ -823,6 +827,7 @@
 			children = (
 				A2FFBC8E2A94986200039919 /* FillBoxViewModel.swift */,
 				A282DA512A94BB2400A0D0BF /* DetailParentViewModel.swift */,
+				A25988F52A965E9700C6BDE0 /* AddParentGoalViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -1179,6 +1184,7 @@
 				A2FA59102A7FCFB4006ACA2E /* Encodable+.swift in Sources */,
 				A2D304C92A856B6B00A5BA92 /* StorageBoxViewController.swift in Sources */,
 				A2FA59212A7FD2EC006ACA2E /* BaseTableViewCell.swift in Sources */,
+				A25988F62A965E9700C6BDE0 /* AddParentGoalViewModel.swift in Sources */,
 				A2FA59142A7FCFC8006ACA2E /* Data+.swift in Sources */,
 				C9B2CDD82A8A7B26006289A8 /* ViewModelBindableType.swift in Sources */,
 				A2FA591D2A7FD2DD006ACA2E /* BaseCollectionViewCell.swift in Sources */,
@@ -1256,6 +1262,7 @@
 				A2FA591A2A7FD2CF006ACA2E /* BaseViewController.swift in Sources */,
 				A2FA592A2A7FD3BA006ACA2E /* UITableView+.swift in Sources */,
 				A2C98F032A8B6117009B5579 /* AddParentGoalViewController.swift in Sources */,
+				A25988F72A965E9700C6BDE0 /* AddParentGoalViewModel.swift in Sources */,
 				A2B20D952A7ED174001ED73C /* UIImage+.swift in Sources */,
 				A2B20D912A7ED14C001ED73C /* ImageLiteral.swift in Sources */,
 				A28EDA1A2A879565001A021A /* DetailParentViewController.swift in Sources */,
@@ -1328,6 +1335,7 @@
 				A2B20D9C2A7ED40D001ED73C /* Logger.swift in Sources */,
 				A2B20D5B2A7E4E5C001ED73C /* UIFont+.swift in Sources */,
 				A2B20D962A7ED174001ED73C /* UIImage+.swift in Sources */,
+				A25988F82A965E9700C6BDE0 /* AddParentGoalViewModel.swift in Sources */,
 				A28EDA132A87808A001A021A /* UIViewController+.swift in Sources */,
 				A227368C2A7CE53800D7B3B2 /* MilestoneUITestsLaunchTests.swift in Sources */,
 				A2B20D632A7E4FAD001ED73C /* UIView+.swift in Sources */,

--- a/Milestone/Milestone/Core/API/APIRouter.swift
+++ b/Milestone/Milestone/Core/API/APIRouter.swift
@@ -19,7 +19,7 @@ enum APIRouter: URLRequestConvertible {
     case requestGoalCountByStatus
     case editGoal(id: Int, goal: Goal)
     case recoverGoal(id: Int, startDate: String, endDate: String, reminderEnabled: Bool)
-    case postGoal(goal: Goal)
+    case postGoal(goal: CreateParentGoal)
     
     /// 유저 관련 API 리스트
     case reissue

--- a/Milestone/Milestone/Core/Services/ServicesGoalList.swift
+++ b/Milestone/Milestone/Core/Services/ServicesGoalList.swift
@@ -12,6 +12,7 @@ import RxSwift
 protocol ServicesGoalList: Service {
     func requestAllGoals(goalStatusParameter: GoalStatusParameter) -> Observable<Result<BaseModel<GoalResponse>, APIError>>
     func requestGoalCountByStatus() -> Observable<Result<BaseModel<ParentGoalCount>, APIError>>
+    func requestPostParentGoal(reqBody: CreateParentGoal) -> Observable<Result<EmptyDataModel, APIError>>
 }
 
 extension ServicesGoalList {
@@ -20,5 +21,8 @@ extension ServicesGoalList {
     }
     func requestGoalCountByStatus() -> Observable<Result<BaseModel<ParentGoalCount>, APIError>> {
         return apiSession.request(.requestGoalCountByStatus)
+    }
+    func requestPostParentGoal(reqBody: CreateParentGoal) -> Observable<Result<EmptyDataModel, APIError>> {
+        return apiSession.request(.postGoal(goal: reqBody))
     }
 }

--- a/Milestone/Milestone/Global/Base/BaseModel.swift
+++ b/Milestone/Milestone/Global/Base/BaseModel.swift
@@ -12,3 +12,11 @@ struct BaseModel<T: Codable>: Codable {
     let message: String
     let data: T
 }
+
+// MARK: - data가 비었을 경우에 사용!
+
+struct EmptyDataModel: Codable {
+    let code: Int
+    let message: String
+    let data: [String: String]
+}

--- a/Milestone/Milestone/Global/Base/ViewModelBindableType.swift
+++ b/Milestone/Milestone/Global/Base/ViewModelBindableType.swift
@@ -22,4 +22,7 @@ extension ViewModelBindableType where Self: UIViewController {
         loadViewIfNeeded()
         bindViewModel()
     }
+    func bindViewModel() {
+        // bind가 필요없는 경우 ViewModelBindableType 채택 시 굳이 이 함수를 작성하지 않아도 돌아가게끔 하려고
+    }
 }

--- a/Milestone/Milestone/Model/ParentGoal.swift
+++ b/Milestone/Milestone/Model/ParentGoal.swift
@@ -45,3 +45,12 @@ struct Count: Codable {
     var PROCESS: Int
     var COMPLETE: Int
 }
+
+// MARK: - 상위 목표 생성 모델
+
+struct CreateParentGoal: Codable {
+    var title: String
+    var startDate: String
+    var endDate: String
+    var reminderEnabled: Bool
+}

--- a/Milestone/Milestone/Screens/FillBox/Protocol/UpdateParentGoalListDelegate.swift
+++ b/Milestone/Milestone/Screens/FillBox/Protocol/UpdateParentGoalListDelegate.swift
@@ -1,0 +1,13 @@
+//
+//  UpdateParentGoalListDelegate.swift
+//  Milestone
+//
+//  Created by 서은수 on 2023/08/24.
+//
+
+import Foundation
+
+/// 채움함이 아닌 다른 뷰에서 상위 목표 리스트를 업데이트 할 때 사용
+protocol UpdateParentGoalListDelegate: AnyObject {
+    func updateParentGoalList()
+}

--- a/Milestone/Milestone/Screens/FillBox/View/AddParentGoalViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/AddParentGoalViewController.swift
@@ -12,7 +12,7 @@ import Then
 
 // MARK: - 상위 목표 추가 모달뷰
 
-class AddParentGoalViewController: BaseViewController {
+class AddParentGoalViewController: BaseViewController, ViewModelBindableType {
     
     // MARK: - SubViews
     
@@ -46,6 +46,7 @@ class AddParentGoalViewController: BaseViewController {
     
     // MARK: - Properties
     
+    var viewModel: AddParentGoalViewModel!
     let viewHeight = 549.0
     
     // MARK: - Functions
@@ -102,8 +103,11 @@ class AddParentGoalViewController: BaseViewController {
     
     @objc
     private func completeAddParentGoal() {
-        updateButtonState(.press)
+        // 상위 목표 생성 API 호출
+        let reqBody = CreateParentGoal(title: self.enterGoalTitleView.titleTextField.text ?? " ", startDate: self.enterGoalDateView.startDateButton.titleLabel?.text ?? "", endDate: self.enterGoalDateView.endDateButton.titleLabel?.text ?? "", reminderEnabled: self.reminderAlarmView.onOffSwitch.isOn)
+        viewModel.createParentGoal(reqBody: reqBody)
         
+        updateButtonState(.press)
         // 버튼 업데이트 보여주기 위해 0.1초만 딜레이 후 dismiss
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             self.dismiss(animated: true)

--- a/Milestone/Milestone/Screens/FillBox/View/AddParentGoalViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/AddParentGoalViewController.swift
@@ -48,6 +48,7 @@ class AddParentGoalViewController: BaseViewController, ViewModelBindableType {
     
     var viewModel: AddParentGoalViewModel!
     let viewHeight = 549.0
+    var delegate: UpdateParentGoalListDelegate?
     
     // MARK: - Functions
     
@@ -110,7 +111,10 @@ class AddParentGoalViewController: BaseViewController, ViewModelBindableType {
         updateButtonState(.press)
         // 버튼 업데이트 보여주기 위해 0.1초만 딜레이 후 dismiss
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            self.dismiss(animated: true)
+            self.dismiss(animated: true) {
+                // 목표 추가 모달 dismiss 하면서 상위 목표 목록 업데이트
+                self.delegate?.updateParentGoalList()
+            }
         }
     }
 }

--- a/Milestone/Milestone/Screens/FillBox/View/FillBoxViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/FillBoxViewController.swift
@@ -104,7 +104,6 @@ class FillBoxViewController: BaseViewController, ViewModelBindableType {
         viewModel.completedGoalCount
             .bind(to: parentGoalHeaderView.completedGoalView.goalNumberLabel.rx.text)
             .disposed(by: disposeBag)
-        viewModel.createParentGoal()
     }
     
     /// 처음이 맞는지 확인 -> 맞으면 말풍선 뷰 띄우기
@@ -139,7 +138,8 @@ class FillBoxViewController: BaseViewController, ViewModelBindableType {
     }
     
     private func presentAddParentGoal() {
-        let addParentGoalVC = AddParentGoalViewController()
+        var addParentGoalVC = AddParentGoalViewController()
+        addParentGoalVC.bind(viewModel: AddParentGoalViewModel())
         presentCustomModal(addParentGoalVC, height: addParentGoalVC.viewHeight)
     }
     

--- a/Milestone/Milestone/Screens/FillBox/View/FillBoxViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/FillBoxViewController.swift
@@ -104,6 +104,7 @@ class FillBoxViewController: BaseViewController, ViewModelBindableType {
         viewModel.completedGoalCount
             .bind(to: parentGoalHeaderView.completedGoalView.goalNumberLabel.rx.text)
             .disposed(by: disposeBag)
+        viewModel.createParentGoal()
     }
     
     /// 처음이 맞는지 확인 -> 맞으면 말풍선 뷰 띄우기

--- a/Milestone/Milestone/Screens/FillBox/ViewModel/AddParentGoalViewModel.swift
+++ b/Milestone/Milestone/Screens/FillBox/ViewModel/AddParentGoalViewModel.swift
@@ -1,0 +1,42 @@
+//
+//  AddParentGoalViewModel.swift
+//  Milestone
+//
+//  Created by 서은수 on 2023/08/24.
+//
+
+import UIKit
+
+import RxCocoa
+import RxSwift
+
+class AddParentGoalViewModel: BindableViewModel, ServicesGoalList {
+    
+    // MARK: - BindableViewModel Properties
+    
+    var apiSession: APIService = APISession()
+    var bag = DisposeBag()
+    
+    deinit {
+        bag = DisposeBag()
+    }
+}
+
+extension AddParentGoalViewModel {
+    func createParentGoal(reqBody: CreateParentGoal) {
+        var createParentGoalResponse: Observable<Result<EmptyDataModel, APIError>> {
+            requestPostParentGoal(reqBody: reqBody)
+        }
+        
+        createParentGoalResponse
+            .subscribe(onNext: { result in
+                switch result {
+                case .success(let response):
+                    Logger.debugDescription(response)
+                case .failure(let error):
+                    Logger.debugDescription(error)
+                }
+            })
+            .disposed(by: bag)
+    }
+}

--- a/Milestone/Milestone/Screens/FillBox/ViewModel/FillBoxViewModel.swift
+++ b/Milestone/Milestone/Screens/FillBox/ViewModel/FillBoxViewModel.swift
@@ -16,7 +16,6 @@ class FillBoxViewModel: BindableViewModel, ServicesGoalList {
     
     var apiSession: APIService = APISession()
     var bag = DisposeBag()
-    var test = CreateParentGoal(title: "test", startDate: "2023-08-08", endDate: "2023-08-26", reminderEnabled: true)
     
     // MARK: - Output
     
@@ -25,9 +24,6 @@ class FillBoxViewModel: BindableViewModel, ServicesGoalList {
     }
     var parentGoalListResponse: Observable<Result<BaseModel<GoalResponse>, APIError>> {
         requestAllGoals(goalStatusParameter: .process)
-    }
-    var createParentGoalResponse: Observable<Result<EmptyDataModel, APIError>> {
-        requestPostParentGoal(reqBody: test)
     }
     
     var progressGoalCount = BehaviorRelay<String>(value: "0")
@@ -61,20 +57,6 @@ extension FillBoxViewModel {
                 switch result {
                 case .success(let response):
                     progressGoals.accept(response.data.contents)
-                case .failure(let error):
-                    Logger.debugDescription(error)
-                }
-            })
-            .disposed(by: bag)
-    }
-    
-    func createParentGoal() {
-        createParentGoalResponse
-            .subscribe(onNext: { result in
-                switch result {
-                case .success(let response):
-                    Logger.debugDescription(response)
-//                    progressGoals.accept(response.data.contents)
                 case .failure(let error):
                     Logger.debugDescription(error)
                 }

--- a/Milestone/Milestone/Screens/FillBox/ViewModel/FillBoxViewModel.swift
+++ b/Milestone/Milestone/Screens/FillBox/ViewModel/FillBoxViewModel.swift
@@ -16,6 +16,7 @@ class FillBoxViewModel: BindableViewModel, ServicesGoalList {
     
     var apiSession: APIService = APISession()
     var bag = DisposeBag()
+    var test = CreateParentGoal(title: "test", startDate: "2023-08-08", endDate: "2023-08-26", reminderEnabled: true)
     
     // MARK: - Output
     
@@ -24,6 +25,9 @@ class FillBoxViewModel: BindableViewModel, ServicesGoalList {
     }
     var parentGoalListResponse: Observable<Result<BaseModel<GoalResponse>, APIError>> {
         requestAllGoals(goalStatusParameter: .process)
+    }
+    var createParentGoalResponse: Observable<Result<EmptyDataModel, APIError>> {
+        requestPostParentGoal(reqBody: test)
     }
     
     var progressGoalCount = BehaviorRelay<String>(value: "0")
@@ -57,6 +61,20 @@ extension FillBoxViewModel {
                 switch result {
                 case .success(let response):
                     progressGoals.accept(response.data.contents)
+                case .failure(let error):
+                    Logger.debugDescription(error)
+                }
+            })
+            .disposed(by: bag)
+    }
+    
+    func createParentGoal() {
+        createParentGoalResponse
+            .subscribe(onNext: { result in
+                switch result {
+                case .success(let response):
+                    Logger.debugDescription(response)
+//                    progressGoals.accept(response.data.contents)
                 case .failure(let error):
                     Logger.debugDescription(error)
                 }

--- a/Milestone/Milestone/Screens/Main/View/MainViewController.swift
+++ b/Milestone/Milestone/Screens/Main/View/MainViewController.swift
@@ -138,7 +138,7 @@ class MainViewController: BaseViewController {
     
     /// 세 개의 섹션들에 대해 뷰모델 바인딩
     func bindingModels() {
-        fillBoxVC.bind(viewModel: FillBoxViewModel())
+//        fillBoxVC.bind(viewModel: FillBoxViewModel())
         completionVC.bind(viewModel: CompletionViewModel())
     }
     


### PR DESCRIPTION
## 상세 내용
- #116  
1. 상위 목표 생성 API 연동 -> `AddParentGoalViewModel` 작성
2. 상위 목표 추가 모달 뷰에서 목표를 생성하고 모달 뷰를 `dismiss` 하면
- 채움함 메인의 **상위 목표 리스트**가 다시 조회되고,
- 채움함 메인 상단의 **상태별 상위 목표 개수**가 다시 조회되도록 구현하였습니다.
-> `FillBox > Protocol > UpdateParentGoalListDelegate`에 프로토콜을 만들어 Delegate Pattern 사용

## 시연 영상
https://github.com/dnd-side-project/dnd-9th-1-ios/assets/87434861/50ff49fd-fb93-4bdf-b47f-1f4d48b0e4e0

## 이슈 1. API를 bindViewModel말고 생명주기 함수 안에서 호출하고 싶은데... VM이 nil?!
- 문제 1 : `bindViewModel`을 생명주기 함수 안에서 호출하고 싶은데 (예: `viewWillAppear`에서 API를 호출하여 채움함이 보여질 때마다 리스트 다시 조회하려고) 원래의 `MainVC`의 코드 `fillBoxVC.bind(viewModel: FillBoxViewModel())`에서 `bind` 함수 때문에 `bindViewModel`이 자동으로 실행돼버림
-> 그럼 `bind`를 지우고 우리 슬랙에서 얘기했던 것처럼 직접 인스턴스 할당으로 하면? -> 문제 2 발생
- 문제 2 : 채움함의 경우 `MainVC`에서 가장 처음으로 나오는 화면이라서 
`MainVC`의 `bindingModels` 함수에서 `fillBoxVC.viewModel = FillBoxViewModel()` 이렇게 작성하고 `FillBoxVC`의 `viewDidLoad`에서 `bindViewModel`을 호출하면 이때 `viewModel`이 **nil**이라고 에러가 발생함.
-> 그럼 `FillBoxVC`에서 `viewModel` 값이 무조건 nil이 아니어야 함 -> 그렇게 하려면 VC에서 VM을 선언할 때 동시에 초기화를 하자!
- 해결 : `MainVC`의 `bind`를 지우고`FillBoxVC` 안에서 `viewModel` 변수를 선언할 때 초기화하였습니다. 
```
var viewModel: FillBoxViewModel! = FillBoxViewModel()
```
- 그 후 `viewDidLoad`에서는 `bindViewModel`을 호출하고, `viewWillAppear`에서는 상위 목표 조회 API를 호출하여 원하는 동작을 구현함.

## 기타
- `ViewModelBindableType`에서 `bindViewModel`을 미리 빈 함수로 구현해 놓았습니다!
-> 이유 : 뷰와 `bind`를 할 필요없는 VC의 경우 `ViewModelBindableType` 채택 시 굳이 `bindViewModel` 함수를 작성하지 않아도 돌아가게끔 하기 위해서

## 셀프 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩 컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 오른쪽의 Development에서 이슈와 연결하였는가?
