### PR TITLE
[#122] 세부 목표 리스트 조회 API 연동 및 뷰와 연결

### DIFF
--- a/Milestone/Milestone.xcodeproj/project.pbxproj
+++ b/Milestone/Milestone.xcodeproj/project.pbxproj
@@ -31,6 +31,9 @@
 		A23E8BA22A9013610051D135 /* AskOneOfTwoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23E8BA12A9013610051D135 /* AskOneOfTwoView.swift */; };
 		A252C4B52A92B5AB0067B89C /* ParentGoal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A252C4B32A92B5AB0067B89C /* ParentGoal.swift */; };
 		A252C4B62A92B5AB0067B89C /* ParentGoal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A252C4B32A92B5AB0067B89C /* ParentGoal.swift */; };
+		A25988FE2A96915F00C6BDE0 /* ServicesDetailGoal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25988FD2A96915E00C6BDE0 /* ServicesDetailGoal.swift */; };
+		A25988FF2A96915F00C6BDE0 /* ServicesDetailGoal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25988FD2A96915E00C6BDE0 /* ServicesDetailGoal.swift */; };
+		A25989002A96915F00C6BDE0 /* ServicesDetailGoal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25988FD2A96915E00C6BDE0 /* ServicesDetailGoal.swift */; };
 		A265090C2A8D458300E9A2D7 /* BubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A265090B2A8D458300E9A2D7 /* BubbleView.swift */; };
 		A26509102A8D604100E9A2D7 /* CouchMarkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A265090F2A8D604100E9A2D7 /* CouchMarkViewController.swift */; };
 		A26509112A8D604100E9A2D7 /* CouchMarkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A265090F2A8D604100E9A2D7 /* CouchMarkViewController.swift */; };
@@ -294,6 +297,7 @@
 		A23E8B9F2A900EEC0051D135 /* DeleteGoalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteGoalViewController.swift; sourceTree = "<group>"; };
 		A23E8BA12A9013610051D135 /* AskOneOfTwoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AskOneOfTwoView.swift; sourceTree = "<group>"; };
 		A252C4B32A92B5AB0067B89C /* ParentGoal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentGoal.swift; sourceTree = "<group>"; };
+		A25988FD2A96915E00C6BDE0 /* ServicesDetailGoal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServicesDetailGoal.swift; sourceTree = "<group>"; };
 		A265090B2A8D458300E9A2D7 /* BubbleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BubbleView.swift; sourceTree = "<group>"; };
 		A265090F2A8D604100E9A2D7 /* CouchMarkViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouchMarkViewController.swift; sourceTree = "<group>"; };
 		A26509132A8DE1BA00E9A2D7 /* AddDetailGoalStoneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddDetailGoalStoneView.swift; sourceTree = "<group>"; };
@@ -902,6 +906,7 @@
 				C9B2CE1F2A8F62B2006289A8 /* Service.swift */,
 				C9B2CE212A8F672C006289A8 /* ServicesUser.swift */,
 				C9B2CE232A8F673C006289A8 /* ServicesGoalList.swift */,
+				A25988FD2A96915E00C6BDE0 /* ServicesDetailGoal.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1156,6 +1161,7 @@
 				C9040FCC2A93B64A00270E94 /* Token.swift in Sources */,
 				C9040FCE2A93BDB400270E94 /* APIInterceptor.swift in Sources */,
 				A2248E832A8818AD00EB995A /* DetailGoalTableViewCell.swift in Sources */,
+				A25988FE2A96915F00C6BDE0 /* ServicesDetailGoal.swift in Sources */,
 				A282DA562A94C20300A0D0BF /* DetailGoalInfo.swift in Sources */,
 				A2EC47D02A8A968A00401B03 /* DetailGoalInfoView.swift in Sources */,
 				A289D95C2A9133C7005B7F00 /* PresentDelegate.swift in Sources */,
@@ -1240,6 +1246,7 @@
 				A289D9432A91241C005B7F00 /* UserDefaultsKeyStyle.swift in Sources */,
 				A2FA59222A7FD2EC006ACA2E /* BaseTableViewCell.swift in Sources */,
 				A2EC47CD2A8A962600401B03 /* DetailGoalInfoViewController.swift in Sources */,
+				A25988FF2A96915F00C6BDE0 /* ServicesDetailGoal.swift in Sources */,
 				A289D9612A913400005B7F00 /* UpdateButtonStateDelegate.swift in Sources */,
 				A282DA532A94BB2400A0D0BF /* DetailParentViewModel.swift in Sources */,
 				A282DA572A94C20300A0D0BF /* DetailGoalInfo.swift in Sources */,
@@ -1285,6 +1292,7 @@
 			files = (
 				A2248E892A8A076D00EB995A /* MoreViewController.swift in Sources */,
 				A27C9A0E2A8E4258002C6F44 /* AddDetailGoalViewController.swift in Sources */,
+				A25989002A96915F00C6BDE0 /* ServicesDetailGoal.swift in Sources */,
 				A289D9502A912849005B7F00 /* IndexTextStyle.swift in Sources */,
 				A2FA58DF2A7F7A3E006ACA2E /* (null) in Sources */,
 				A2B20D672A7E5077001ED73C /* UILabel+.swift in Sources */,

--- a/Milestone/Milestone/Core/Services/ServicesDetailGoal.swift
+++ b/Milestone/Milestone/Core/Services/ServicesDetailGoal.swift
@@ -1,0 +1,24 @@
+//
+//  ServicesDetailGoal.swift
+//  Milestone
+//
+//  Created by 서은수 on 2023/08/24.
+//
+
+import Foundation
+
+import RxSwift
+
+// MARK: - 세부 목표와 관련된 서비스 함수 작성
+
+protocol ServicesDetailGoal: Service {
+    // 세부 목표 리스트 조회 API 요청
+    func requestDetailGoalList(id: Int) -> Observable<Result<BaseModel<[DetailGoal]>, APIError>>
+    
+}
+
+extension ServicesDetailGoal {
+    func requestDetailGoalList(id: Int) -> Observable<Result<BaseModel<[DetailGoal]>, APIError>> {
+        return apiSession.request(.requestAllDetailGoal(higherLevelGoalId: id))
+    }
+}

--- a/Milestone/Milestone/Screens/FillBox/View/DetailParentViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/DetailParentViewController.swift
@@ -163,7 +163,8 @@ class DetailParentViewController: BaseViewController, ViewModelBindableType {
     }
     
     func bindViewModel() {
-        viewModel.detailGoalObservableForCollectionView
+        viewModel.retrieveDetailGoalList()
+        viewModel.detailGoalList
             .bind(to: detailGoalCollectionView.rx.items(cellIdentifier: DetailGoalCollectionViewCell.identifier, cellType: DetailGoalCollectionViewCell.self)) { row, goal, cell in
                 // 보관함일 때
                 if self.isFromStorage {
@@ -175,7 +176,7 @@ class DetailParentViewController: BaseViewController, ViewModelBindableType {
             }
             .disposed(by: disposeBag)
         
-        viewModel.detailGoalObservableForTableView
+        viewModel.detailGoalList
             .bind(to: detailGoalTableView.rx.items(cellIdentifier: DetailGoalTableViewCell.identifier, cellType: DetailGoalTableViewCell.self)) { _, goal, cell in
                 if self.isFromStorage {
                     cell.isUserInteractionEnabled = false

--- a/Milestone/Milestone/Screens/FillBox/View/DetailParentViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/DetailParentViewController.swift
@@ -111,7 +111,6 @@ class DetailParentViewController: BaseViewController, ViewModelBindableType {
         super.viewDidLoad()
 
         bindViewModel()
-        setEmptyGoalForCollectionView()
         checkFirstDetailView()
     }
     
@@ -173,23 +172,46 @@ class DetailParentViewController: BaseViewController, ViewModelBindableType {
         detailGoalTableView.snp.updateConstraints { make in
             make.top.equalTo(detailGoalCollectionView.snp.bottom).offset(36)
             make.left.right.equalToSuperview().inset(20)
-            make.height.equalTo(viewModel.detailGoalList.value.count * (56 + 8)) // 상세 목표 개수에 맞게 높이를 업데이트
+            make.height.equalTo(viewModel.test.value.count * (56 + 8)) // 상세 목표 개수에 맞게 높이를 업데이트
         }
     }
     
     func bindViewModel() {
         viewModel.retrieveDetailGoalList()
-        viewModel.detailGoalList
-            .bind(to: detailGoalCollectionView.rx.items(cellIdentifier: DetailGoalCollectionViewCell.identifier, cellType: DetailGoalCollectionViewCell.self)) { row, goal, cell in
-                // 보관함일 때
-                if self.isFromStorage {
-                    cell.isUserInteractionEnabled = false
-                    cell.makeCellBlurry()
+        if viewModel.isFull {
+            viewModel.detailGoalList
+                .bind(to: detailGoalCollectionView.rx.items(cellIdentifier: DetailGoalCollectionViewCell.identifier, cellType: DetailGoalCollectionViewCell.self)) { [unowned self] row, goal, cell in
+                    // 보관함일 때
+                    if self.isFromStorage {
+                        cell.isUserInteractionEnabled = false
+                        cell.makeCellBlurry()
+                    }
+                    
+                    cell.titleLabel.text = goal.title
+                    cell.stoneImageView.image = goal.isCompleted ? self.viewModel.completedImageArray[row] : self.viewModel.stoneImageArray[row]
                 }
-                cell.titleLabel.text = goal.title
-                cell.stoneImageView.image = goal.isCompleted ? self.viewModel.completedImageArray[row] : self.viewModel.stoneImageArray[row]
-            }
-            .disposed(by: disposeBag)
+                .disposed(by: disposeBag)
+        } else {
+            viewModel.test
+                .bind(to: detailGoalCollectionView.rx.items(cellIdentifier: DetailGoalCollectionViewCell.identifier, cellType: DetailGoalCollectionViewCell.self)) { [unowned self] row, goal, cell in
+                    // 보관함일 때
+                    if self.isFromStorage {
+                        cell.isUserInteractionEnabled = false
+                        cell.makeCellBlurry()
+                    }
+                    
+                    Logger.debugDescription(viewModel.detailGoalList.value.count)
+                    if row < viewModel.test.value.count - 1 {
+                        cell.titleLabel.text = goal.title
+                        cell.stoneImageView.image = goal.isCompleted ? self.viewModel.completedImageArray[row] : self.viewModel.stoneImageArray[row]
+                    } else {
+                        cell.titleLabel.text = goal.title
+                        cell.titleLabel.textColor = .gray02
+                        cell.stoneImageView.image = ImageLiteral.imgAddStone
+                    }
+                }
+                .disposed(by: disposeBag)
+        }
         
         viewModel.detailGoalList
             .bind(to: detailGoalTableView.rx.items(cellIdentifier: DetailGoalTableViewCell.identifier, cellType: DetailGoalTableViewCell.self)) { _, goal, cell in
@@ -203,13 +225,6 @@ class DetailParentViewController: BaseViewController, ViewModelBindableType {
                 cell.checkImageView.image = goal.isCompleted ? ImageLiteral.imgBlueCheck : ImageLiteral.imgWhiteCheck
             }
             .disposed(by: disposeBag)
-    }
-    
-    /// 세부 목표를 추가해주세요! 뷰가 필요한 경우를 위해 설정하는 코드
-    private func setEmptyGoalForCollectionView() {
-//        if goalData.count < 9 {
-////            self.emptyGoal = DetailGoalTemp(isSet: false)
-//        }
     }
     
     /// 여기 들어온 게 처음이 맞는지 확인 -> 맞으면 코치 마크 뷰 띄우기
@@ -254,21 +269,6 @@ extension DetailParentViewController: UICollectionViewDelegate {
         return 9
     }
 
-//    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-//        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: DetailGoalCollectionViewCell.identifier, for: indexPath) as? DetailGoalCollectionViewCell else { return UICollectionViewCell() }
-//        if let goal = indexPath.row < goalData.count ? goalData[indexPath.row] : emptyGoal {
-//            cell.update(content: goal, index: indexPath.row)
-//        }
-//        // 보관함일 때
-//        if isFromStorage {
-//            cell.isUserInteractionEnabled = false
-//            cell.makeCellBlurry()
-//        }
-//        return cell
-//    }
-
-    // MARK: - @objc Functions
-
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard let cell = collectionView.cellForItem(at: indexPath) as? DetailGoalCollectionViewCell else { return }
         if cell.isSet.value {
@@ -294,18 +294,6 @@ extension DetailParentViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         9
     }
-
-//    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-//        guard let cell = tableView.dequeueReusableCell(withIdentifier: DetailGoalTableViewCell.identifier, for: indexPath) as? DetailGoalTableViewCell else { return UITableViewCell() }
-//
-//        // 보관함일 때
-//        if isFromStorage {
-//            cell.isUserInteractionEnabled = false
-//            cell.makeCellBlurry()
-//        }
-//        cell.update(content: sortedGoalData[indexPath.row])
-//        return cell
-//    }
 
 //    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
 //        let row = indexPath.row

--- a/Milestone/Milestone/Screens/FillBox/View/DetailParentViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/DetailParentViewController.swift
@@ -102,7 +102,7 @@ class DetailParentViewController: BaseViewController, ViewModelBindableType {
     var viewModel: DetailParentViewModel!
     
     // 세부 목표를 추가해주세요! 데이터
-//    private var emptyGoal: DetailGoalTemp?
+    private var emptyGoal: DetailGoal?
     private var couchMarkKey: String = UserDefaultsKeyStyle.couchMark.rawValue
     
     // MARK: - Life Cycle
@@ -110,8 +110,15 @@ class DetailParentViewController: BaseViewController, ViewModelBindableType {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        bindViewModel()
         setEmptyGoalForCollectionView()
         checkFirstDetailView()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        updateTableViewHeightForFit()
     }
     
     // MARK: - Functions
@@ -151,7 +158,7 @@ class DetailParentViewController: BaseViewController, ViewModelBindableType {
         detailGoalTableView.snp.makeConstraints { make in
             make.top.equalTo(detailGoalCollectionView.snp.bottom).offset(36)
             make.left.right.equalToSuperview().inset(20)
-            make.height.equalTo(10 * (56 + 8))
+            make.height.equalTo(9 * (56 + 8)) // 최대 높이
         }
     }
     
@@ -160,6 +167,14 @@ class DetailParentViewController: BaseViewController, ViewModelBindableType {
         
         self.navigationItem.leftBarButtonItem = leftBarButton
         self.navigationItem.rightBarButtonItem = rightBarButton
+    }
+    
+    private func updateTableViewHeightForFit() {
+        detailGoalTableView.snp.updateConstraints { make in
+            make.top.equalTo(detailGoalCollectionView.snp.bottom).offset(36)
+            make.left.right.equalToSuperview().inset(20)
+            make.height.equalTo(viewModel.detailGoalList.value.count * (56 + 8)) // 상세 목표 개수에 맞게 높이를 업데이트
+        }
     }
     
     func bindViewModel() {
@@ -214,8 +229,6 @@ class DetailParentViewController: BaseViewController, ViewModelBindableType {
         present(couchMarkVC, animated: true)
         UserDefaults.standard.set(true, forKey: couchMarkKey)
     }
-    
-    
     
 //    /// 파라미터로 받은 id가 배열에서 몇 번째 인덱스에 위치해 있는지 반환
 //    private func findIndex(id: Int, goalArray: [DetailGoalTemp]) -> Int? {

--- a/Milestone/Milestone/Screens/FillBox/View/FillBoxViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/FillBoxViewController.swift
@@ -183,7 +183,7 @@ extension FillBoxViewController: UITableViewDelegate {
             }
         lazy var viewModel = DetailParentViewModel()
         viewModel.parentGoalId = selectedGoalData.identity
-        nextVC.bind(viewModel: viewModel)
+        nextVC.viewModel = viewModel
         push(viewController: nextVC)
     }
 }

--- a/Milestone/Milestone/Screens/FillBox/View/FillBoxViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/FillBoxViewController.swift
@@ -175,7 +175,9 @@ extension FillBoxViewController: UITableViewDelegate {
     // 셀 클릭 시 실행
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         var nextVC = DetailParentViewController()
-        nextVC.bind(viewModel: DetailParentViewModel())
+        lazy var viewModel = DetailParentViewModel()
+        viewModel.parentGoalId = self.viewModel.progressGoals.value[indexPath.row].identity
+        nextVC.bind(viewModel: viewModel)
         push(viewController: nextVC)
     }
 }

--- a/Milestone/Milestone/Screens/FillBox/View/FillBoxViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/FillBoxViewController.swift
@@ -174,9 +174,15 @@ extension FillBoxViewController: UITableViewDelegate {
     }
     // 셀 클릭 시 실행
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        var nextVC = DetailParentViewController()
+        let selectedGoalData = self.viewModel.progressGoals.value[indexPath.row]
+        lazy var nextVC = DetailParentViewController()
+            .then {
+                $0.goalTitleLabel.text = selectedGoalData.title
+                $0.dDayLabel.text = "D - \(selectedGoalData.dDay)"
+                $0.termLabel.text = "\(selectedGoalData.startDate) - \(selectedGoalData.endDate)"
+            }
         lazy var viewModel = DetailParentViewModel()
-        viewModel.parentGoalId = self.viewModel.progressGoals.value[indexPath.row].identity
+        viewModel.parentGoalId = selectedGoalData.identity
         nextVC.bind(viewModel: viewModel)
         push(viewController: nextVC)
     }

--- a/Milestone/Milestone/Screens/FillBox/ViewModel/DetailParentViewModel.swift
+++ b/Milestone/Milestone/Screens/FillBox/ViewModel/DetailParentViewModel.swift
@@ -26,10 +26,12 @@ class DetailParentViewModel: BindableViewModel, ServicesDetailGoal {
     let completedImageArray = [ImageLiteral.imgCompletedStoneVer1, ImageLiteral.imgCompletedStoneVer2, ImageLiteral.imgCompletedStoneVer3,
                                ImageLiteral.imgCompletedStoneVer4, ImageLiteral.imgCompletedStoneVer5, ImageLiteral.imgCompletedStoneVer6,
                                ImageLiteral.imgCompletedStoneVer7, ImageLiteral.imgCompletedStoneVer8, ImageLiteral.imgCompletedStoneVer9]
+    var isFull = false // 목표 9개가 꽉 찼는지
     
     // MARK: - Output
     
     var detailGoalList = BehaviorRelay<[DetailGoal]>(value: [])
+    var test = BehaviorRelay<[DetailGoal]>(value: [])
     // detailGoalList를 정렬한, 테이블뷰에 보여줄 데이터
 //    lazy var sortedGoalData: [DetailGoal] = {
 //        return sortGoalForCheckList()
@@ -65,7 +67,14 @@ extension DetailParentViewModel {
             .subscribe(onNext: { [unowned self] result in
                 switch result {
                 case .success(let response):
+                    isFull = response.data.count > 9
                     detailGoalList.accept(response.data)
+                    if !isFull {
+                        // 9개가 다 차지 않았다면 세부 목표 생성 셀 추가
+                        var arr = response.data
+                        arr.append(DetailGoal(detailGoalId: -1, title: "세부 목표를 추가해주세요!", isCompleted: false))
+                        test.accept(arr)
+                    }
                 case .failure(let error):
                     Logger.debugDescription(error)
                 }


### PR DESCRIPTION
## 상세 내용
- #122 
- API 연동 및 그에 따른 뷰 수정
- 상위 목표 리스트에서 셀 클릭 시 세부 목표를 조회할 수 있는 화면이 나오는데 이때 상위 목표의 데이터를 전달하여 화면 상단에 띄워주었다.
- 컬렉션뷰에서 세부 목표가 9개 미만일 때에는 서버로부터 가져온 배열에 `세부 목표를 추가해주세요!` 셀을 추가하여 보여주고, 9개일 때에는 서버로부터 가져온 배열만 보여주도록 했다.
- 테이블뷰는 이런 거 없고 서버로부터 가져온 배열로만 구성한다.

## 셀프 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩 컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 오른쪽의 Development에서 이슈와 연결하였는가?
