### PR TITLE
[#127] 세부 목표 완료 API 연동

### DIFF
--- a/Milestone/Milestone/Core/Services/ServicesDetailGoal.swift
+++ b/Milestone/Milestone/Core/Services/ServicesDetailGoal.swift
@@ -16,6 +16,8 @@ protocol ServicesDetailGoal: Service {
     func requestDetailGoalList(id: Int) -> Observable<Result<BaseModel<[DetailGoal]>, APIError>>
     // 세부 목표 생성 API 요청
     func requestPostDetailGoal(id: Int, reqBody: DetailGoalInfo) -> Observable<Result<EmptyDataModel, APIError>>
+    // 세부 목표 달성 API 요청
+    func requestCompleteDetailGoal(id: Int) -> Observable<Result<BaseModel<CompletedDetailGoal>, APIError>>
 }
 
 extension ServicesDetailGoal {
@@ -24,5 +26,8 @@ extension ServicesDetailGoal {
     }
     func requestPostDetailGoal(id: Int, reqBody: DetailGoalInfo) -> Observable<Result<EmptyDataModel, APIError>> {
         return apiSession.request(.postDetailGoal(higherLevelGoalId: id, detailGoal: reqBody))
+    }
+    func requestCompleteDetailGoal(id: Int) -> Observable<Result<BaseModel<CompletedDetailGoal>, APIError>> {
+        return apiSession.request(.completeDetailGoal(lowerLevelGoalId: id))
     }
 }

--- a/Milestone/Milestone/Global/Base/BaseTableViewCell.swift
+++ b/Milestone/Milestone/Global/Base/BaseTableViewCell.swift
@@ -17,7 +17,7 @@ class BaseTableViewCell: UITableViewCell {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         render()
         configUI()
-        bind()
+        bindUI()
     }
     
     required init?(coder: NSCoder) {
@@ -32,7 +32,7 @@ class BaseTableViewCell: UITableViewCell {
         // Override ConfigUI
     }
     
-    func bind() {
+    func bindUI() {
         // rx
     }
 }

--- a/Milestone/Milestone/Model/DetailGoal.swift
+++ b/Milestone/Milestone/Model/DetailGoal.swift
@@ -14,3 +14,11 @@ struct DetailGoal: Codable {
     let title: String
     var isCompleted: Bool
 }
+
+// MARK: - 세부 목표 완료 시 res 모델
+
+struct CompletedDetailGoal: Codable {
+    var isGoalCompleted: Bool
+    var rewardType: String?
+    var completedGoalCount: Int
+}

--- a/Milestone/Milestone/Screens/FillBox/View/Cell/DetailGoalTableViewCell.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/Cell/DetailGoalTableViewCell.swift
@@ -87,4 +87,22 @@ class DetailGoalTableViewCell: BaseTableViewCell {
             make.edges.equalToSuperview()
         }
     }
+    
+    override func bindUI() {
+        isCompleted
+            .asDriver(onErrorJustReturn: false)
+            .drive(onNext: { [weak self] isCompleted in
+                guard let self = self else { return }
+                self.containerView.backgroundColor = isCompleted ? .secondary03 : .white
+                self.titleLabel.textColor = isCompleted ? .primary : .black
+                self.checkImageView.image = isCompleted ? ImageLiteral.imgBlueCheck : ImageLiteral.imgWhiteCheck
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    /// 셀 내용 업데이트
+    func update(content: DetailGoal) {
+        titleLabel.rx.text.onNext(content.title)
+        isCompleted.accept(content.isCompleted)
+    }
 }

--- a/Milestone/Milestone/Screens/FillBox/View/DetailParentViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/DetailParentViewController.swift
@@ -215,7 +215,7 @@ class DetailParentViewController: BaseViewController, ViewModelBindableType {
                 .disposed(by: disposeBag)
         }
         
-        viewModel.detailGoalList
+        viewModel.sortedGoalData
             .bind(to: detailGoalTableView.rx.items(cellIdentifier: DetailGoalTableViewCell.identifier, cellType: DetailGoalTableViewCell.self)) { _, goal, cell in
                 Logger.debugDescription("여기 \(cell.titleLabel.text)")
                 if self.isFromStorage {
@@ -247,11 +247,6 @@ class DetailParentViewController: BaseViewController, ViewModelBindableType {
         present(couchMarkVC, animated: true)
         UserDefaults.standard.set(true, forKey: couchMarkKey)
     }
-    
-//    /// 파라미터로 받은 id가 배열에서 몇 번째 인덱스에 위치해 있는지 반환
-//    private func findIndex(id: Int, goalArray: [DetailGoalTemp]) -> Int? {
-//        return goalArray.firstIndex { $0.id == id }
-//    }
     
     // MARK: - @objc Functions
     
@@ -301,23 +296,21 @@ extension DetailParentViewController: UITableViewDelegate {
         9
     }
 
-//    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-//        let row = indexPath.row
-//        let selectedGoalId = sortedGoalData[row].id
-//
-//        sortedGoalData[row].isCompleted.toggle() // 원본 배열의 isCompleted 값 변경
-//        sortedGoalData = sortGoalForCheckList(goalArray: sortedGoalData) // 원본 배열 재정렬
-//
-//        let newIndex = findIndex(id: selectedGoalId, goalArray: sortedGoalData) // 재정렬된 배열과 비교하여 완료도가 업데이트된 목표가 들어가야할 인덱스를 찾는다
-//        let destIndexPath = IndexPath(row: newIndex ?? 0, section: 0) // 목적지 indexPath
-//        tableView.moveRow(at: indexPath, to: destIndexPath) // 해당 인덱스로 셀 이동
-//
-//        guard let movedCell = tableView.cellForRow(at: destIndexPath) as? DetailGoalTableViewCell else { return } // 이동한 셀
-//        movedCell.update(content: sortedGoalData[newIndex ?? 0]) // 이동한 셀 UI 업데이트
-//
-//        goalData[selectedGoalId].isCompleted.toggle() // 원본 배열의 isCompleted 값 변경
-//        self.detailGoalCollectionView.reloadData()
-//    }
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        guard let cell = tableView.cellForRow(at: indexPath) as? DetailGoalTableViewCell else { return }
+        let sortedGoalData = viewModel.sortedGoalData.value
+        let row = indexPath.row
+        let selectedGoalId = sortedGoalData[row].detailGoalId
+        
+        if cell.containerView.backgroundColor == .white {
+            // 세부 목표 달성
+            viewModel.detailGoalId = selectedGoalId
+            viewModel.completeDetailGoal()
+            cell.update(content: sortedGoalData[row])
+        } else {
+            // 세부 목표 달성 취소
+        }
+    }
 }
 
 // MARK: - UpdateDetailGoalListDelegate

--- a/Milestone/Milestone/Screens/FillBox/ViewModel/DetailParentViewModel.swift
+++ b/Milestone/Milestone/Screens/FillBox/ViewModel/DetailParentViewModel.swift
@@ -20,6 +20,8 @@ class DetailParentViewModel: BindableViewModel, ServicesDetailGoal {
     // MARK: - Properties
     
     var parentGoalId: Int = 0
+    var detailGoalId: Int = 0
+    var selectedParentGoal: ParentGoal?
     let stoneImageArray = [ImageLiteral.imgDetailStoneVer1, ImageLiteral.imgDetailStoneVer2, ImageLiteral.imgDetailStoneVer3,
                            ImageLiteral.imgDetailStoneVer4, ImageLiteral.imgDetailStoneVer5, ImageLiteral.imgDetailStoneVer6,
                            ImageLiteral.imgDetailStoneVer7, ImageLiteral.imgDetailStoneVer8, ImageLiteral.imgDetailStoneVer9]
@@ -33,12 +35,13 @@ class DetailParentViewModel: BindableViewModel, ServicesDetailGoal {
     var detailGoalList = BehaviorRelay<[DetailGoal]>(value: [])
     var test = BehaviorRelay<[DetailGoal]>(value: [])
     // detailGoalList를 정렬한, 테이블뷰에 보여줄 데이터
-//    lazy var sortedGoalData: [DetailGoal] = {
-//        return sortGoalForCheckList()
-//    }()
+    lazy var sortedGoalData = BehaviorRelay<[DetailGoal]>(value: sortGoalForCheckList())
     
     var detailGoalListResponse: Observable<Result<BaseModel<[DetailGoal]>, APIError>> {
         requestDetailGoalList(id: parentGoalId)
+    }
+    var detailGoalCompleteResponse: Observable<Result<BaseModel<CompletedDetailGoal>, APIError>> {
+        requestCompleteDetailGoal(id: detailGoalId)
     }
     
     deinit {
@@ -50,15 +53,15 @@ class DetailParentViewModel: BindableViewModel, ServicesDetailGoal {
     /// 체크리스트(TableView)를 위해 detailGoalList를 정렬하는 함수
     /// 리스트는 id순(작성순)으로 정렬되어야 한다
     /// 또한 완료된 목표는 완료되지 않은 목표들보다 뒤에 위치해야 한다
-//    private func sortGoalForCheckList() -> [DetailGoal] {
-//        return detailGoalList.sorted {
-//            if $0.isCompleted == $1.isCompleted {
-//                return $0.detailGoalId < $1.detailGoalId
-//            } else {
-//                return !$0.isCompleted && $1.isCompleted
-//            }
-//        }
-//    }
+    private func sortGoalForCheckList() -> [DetailGoal] {
+        return detailGoalList.value.sorted {
+            if $0.isCompleted == $1.isCompleted {
+                return $0.detailGoalId < $1.detailGoalId
+            } else {
+                return !$0.isCompleted && $1.isCompleted
+            }
+        }
+    }
 }
 
 extension DetailParentViewModel {
@@ -69,6 +72,7 @@ extension DetailParentViewModel {
                 case .success(let response):
                     isFull = response.data.count > 9
                     detailGoalList.accept(response.data)
+                    sortedGoalData.accept(sortGoalForCheckList()) // 정렬
                     if !isFull {
                         // 9개가 다 차지 않았다면 세부 목표 생성 셀 추가
                         var arr = response.data
@@ -79,6 +83,20 @@ extension DetailParentViewModel {
                     Logger.debugDescription(error)
                 }
             })
+            .disposed(by: bag)
+    }
+    
+    func completeDetailGoal() {
+        detailGoalCompleteResponse
+            .subscribe { [unowned self] result in
+                switch result {
+                case .success(let response):
+                    retrieveDetailGoalList()
+                    Logger.debugDescription(response)
+                case .failure(let error):
+                    Logger.debugDescription(error)
+                }
+            }
             .disposed(by: bag)
     }
 }


### PR DESCRIPTION
## 상세 내용
- #127 
- 세부 목표 완료 API 연동
- 테이블뷰 셀 클릭 시 **세부 목표 API**가 호출되고, 그 이후에는 다시 **세부 목표 리스트 조회 API**가 호출되어 업데이트 된 세부 목표 리스트에 따라 **테이블뷰와 컬렉션뷰의 UI도 업데이트** 된다.

## 기타
- 세부 목표 완료 시 바로 목록도 업데이트 하기 위해 세부 목표 리스트 조회 API가 호출이 되는데, 이것 때문에 이전처럼(#15) 애니메이션과 함께 셀이 이동하는 것은 볼 수 없게 되었다 🥲 -> 애니메이션을 보려면 서버에서 API res를 바꿔줘야 돼서 나중에 바꿀 수 있으면 좋을 듯

## 셀프 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩 컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 오른쪽의 Development에서 이슈와 연결하였는가?
