### PR TITLE
[#128] 세부 목표 완료 취소 API 연동

### DIFF
--- a/Milestone/Milestone/Core/Services/ServicesDetailGoal.swift
+++ b/Milestone/Milestone/Core/Services/ServicesDetailGoal.swift
@@ -19,7 +19,7 @@ protocol ServicesDetailGoal: Service {
     // 세부 목표 완료 API 요청
     func requestCompleteDetailGoal(id: Int) -> Observable<Result<BaseModel<CompletedDetailGoal>, APIError>>
     // 세부 목표 완료 취소 API 요청
-    func requestIncompleteDetailGoal(id: Int) -> Observable<Result<BaseModel<CompletedDetailGoal>, APIError>>
+    func requestIncompleteDetailGoal(id: Int) -> Observable<Result<EmptyDataModel, APIError>>
 }
 
 extension ServicesDetailGoal {
@@ -32,7 +32,7 @@ extension ServicesDetailGoal {
     func requestCompleteDetailGoal(id: Int) -> Observable<Result<BaseModel<CompletedDetailGoal>, APIError>> {
         return apiSession.request(.completeDetailGoal(lowerLevelGoalId: id))
     }
-    func requestIncompleteDetailGoal(id: Int) -> Observable<Result<BaseModel<CompletedDetailGoal>, APIError>> {
+    func requestIncompleteDetailGoal(id: Int) -> Observable<Result<EmptyDataModel, APIError>> {
         return apiSession.request(.incompleteDetailGoal(lowerLevelGoalId: id))
     }
 }

--- a/Milestone/Milestone/Core/Services/ServicesDetailGoal.swift
+++ b/Milestone/Milestone/Core/Services/ServicesDetailGoal.swift
@@ -16,8 +16,10 @@ protocol ServicesDetailGoal: Service {
     func requestDetailGoalList(id: Int) -> Observable<Result<BaseModel<[DetailGoal]>, APIError>>
     // 세부 목표 생성 API 요청
     func requestPostDetailGoal(id: Int, reqBody: DetailGoalInfo) -> Observable<Result<EmptyDataModel, APIError>>
-    // 세부 목표 달성 API 요청
+    // 세부 목표 완료 API 요청
     func requestCompleteDetailGoal(id: Int) -> Observable<Result<BaseModel<CompletedDetailGoal>, APIError>>
+    // 세부 목표 완료 취소 API 요청
+    func requestIncompleteDetailGoal(id: Int) -> Observable<Result<BaseModel<CompletedDetailGoal>, APIError>>
 }
 
 extension ServicesDetailGoal {
@@ -29,5 +31,8 @@ extension ServicesDetailGoal {
     }
     func requestCompleteDetailGoal(id: Int) -> Observable<Result<BaseModel<CompletedDetailGoal>, APIError>> {
         return apiSession.request(.completeDetailGoal(lowerLevelGoalId: id))
+    }
+    func requestIncompleteDetailGoal(id: Int) -> Observable<Result<BaseModel<CompletedDetailGoal>, APIError>> {
+        return apiSession.request(.incompleteDetailGoal(lowerLevelGoalId: id))
     }
 }

--- a/Milestone/Milestone/Global/Base/BaseModel.swift
+++ b/Milestone/Milestone/Global/Base/BaseModel.swift
@@ -18,5 +18,5 @@ struct BaseModel<T: Codable>: Codable {
 struct EmptyDataModel: Codable {
     let code: Int
     let message: String
-    let data: [String: String]
+    let data: [String: String]?
 }

--- a/Milestone/Milestone/Screens/FillBox/View/Cell/ParentGoalTableViewCell.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/Cell/ParentGoalTableViewCell.swift
@@ -54,6 +54,15 @@ class ParentGoalTableViewCell: BaseTableViewCell {
     
     // MARK: - Functions
     
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        goalAchievementRateView.totalCount = CGFloat(0)
+        goalAchievementRateView.completedCount = CGFloat(0)
+        titleLabel.text = ""
+        termLabel.text = ""
+    }
+    
     override func configUI() {
         self.backgroundColor = .gray01
         self.selectionStyle = .none

--- a/Milestone/Milestone/Screens/FillBox/View/DetailParentViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/DetailParentViewController.swift
@@ -217,15 +217,11 @@ class DetailParentViewController: BaseViewController, ViewModelBindableType {
         
         viewModel.sortedGoalData
             .bind(to: detailGoalTableView.rx.items(cellIdentifier: DetailGoalTableViewCell.identifier, cellType: DetailGoalTableViewCell.self)) { _, goal, cell in
-                Logger.debugDescription("여기 \(cell.titleLabel.text)")
                 if self.isFromStorage {
                     cell.isUserInteractionEnabled = false
                     cell.makeCellBlurry()
                 }
-                cell.titleLabel.text = goal.title
-                cell.containerView.backgroundColor = goal.isCompleted ? .secondary03 : .white
-                cell.titleLabel.textColor = goal.isCompleted ? .primary : .black
-                cell.checkImageView.image = goal.isCompleted ? ImageLiteral.imgBlueCheck : ImageLiteral.imgWhiteCheck
+                cell.update(content: goal)
             }
             .disposed(by: disposeBag)
     }
@@ -300,15 +296,15 @@ extension DetailParentViewController: UITableViewDelegate {
         guard let cell = tableView.cellForRow(at: indexPath) as? DetailGoalTableViewCell else { return }
         let sortedGoalData = viewModel.sortedGoalData.value
         let row = indexPath.row
-        let selectedGoalId = sortedGoalData[row].detailGoalId
+        let selectedGoal = sortedGoalData[row]
         
+        viewModel.detailGoalId = selectedGoal.detailGoalId
         if cell.containerView.backgroundColor == .white {
             // 세부 목표 달성
-            viewModel.detailGoalId = selectedGoalId
             viewModel.completeDetailGoal()
-            cell.update(content: sortedGoalData[row])
         } else {
             // 세부 목표 달성 취소
+            viewModel.incompleteDetailGoal()
         }
     }
 }

--- a/Milestone/Milestone/Screens/FillBox/ViewModel/DetailParentViewModel.swift
+++ b/Milestone/Milestone/Screens/FillBox/ViewModel/DetailParentViewModel.swift
@@ -43,6 +43,9 @@ class DetailParentViewModel: BindableViewModel, ServicesDetailGoal {
     var detailGoalCompleteResponse: Observable<Result<BaseModel<CompletedDetailGoal>, APIError>> {
         requestCompleteDetailGoal(id: detailGoalId)
     }
+    var detailGoalIncompleteResponse: Observable<Result<EmptyDataModel, APIError>> {
+        requestIncompleteDetailGoal(id: detailGoalId)
+    }
     
     deinit {
         bag = DisposeBag()
@@ -88,6 +91,20 @@ extension DetailParentViewModel {
     
     func completeDetailGoal() {
         detailGoalCompleteResponse
+            .subscribe { [unowned self] result in
+                switch result {
+                case .success(let response):
+                    retrieveDetailGoalList()
+                    Logger.debugDescription(response)
+                case .failure(let error):
+                    Logger.debugDescription(error)
+                }
+            }
+            .disposed(by: bag)
+    }
+    
+    func incompleteDetailGoal() {
+        detailGoalIncompleteResponse
             .subscribe { [unowned self] result in
                 switch result {
                 case .success(let response):


### PR DESCRIPTION
## 상세 내용
- #128 
- 세부 목표 완료 취소 API 연동
- 이미 완료된 목표를 테이블뷰 셀에서 클릭 시 세부 목표 완료 취소 API로 요청을 보내고 성공 시 하위 목표 목록을 업데이트 하였다.
- 데이터 값에 따라 셀의 UI를 업데이트 하였다.

## 셀프 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩 컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 오른쪽의 Development에서 이슈와 연결하였는가?
