### PR TITLE
[#130] 상위 목표 삭제 API 연동

### DIFF
--- a/Milestone/Milestone/Core/Services/ServicesGoalList.swift
+++ b/Milestone/Milestone/Core/Services/ServicesGoalList.swift
@@ -24,6 +24,8 @@ protocol ServicesGoalList: Service {
     func requestPostParentGoal(reqBody: CreateParentGoal) -> Observable<Result<EmptyDataModel, APIError>>
 
     func requestModifyParentGoal(id: Int, reqBody: Goal) -> Observable<Result<BaseModel<ParentGoalInfo>, APIError>>
+    
+    func requestDeleteParentGoal(id: Int) -> Observable<Result<EmptyDataModel, APIError>>
 }
 
 extension ServicesGoalList {
@@ -54,5 +56,10 @@ extension ServicesGoalList {
     // 상위 목표 수정
     func requestModifyParentGoal(id: Int, reqBody: Goal) -> Observable<Result<BaseModel<ParentGoalInfo>, APIError>> {
         return apiSession.request(.editGoal(id: id, goal: reqBody))
+    }
+    
+    // 상위 목표 삭제
+    func requestDeleteParentGoal(id: Int) -> Observable<Result<EmptyDataModel, APIError>> {
+        return apiSession.request(.deleteGoal(id: id))
     }
 }

--- a/Milestone/Milestone/Global/Component/Shared/RoundedButton.swift
+++ b/Milestone/Milestone/Global/Component/Shared/RoundedButton.swift
@@ -171,3 +171,11 @@ class RoundedButton: UIButton {
         }
     }
 }
+
+// MARK: - UpdateButtonStateDelegate
+
+extension RoundedButton: UpdateButtonStateDelegate {
+    func updateButtonState(_ state: ButtonState) {
+        self.buttonState = state
+    }
+}

--- a/Milestone/Milestone/Screens/FillBox/View/DeleteGoalViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/DeleteGoalViewController.swift
@@ -12,7 +12,7 @@ import Then
 
 // MARK: - 목표 삭제 팝업 뷰 (상위, 세부 목표 동일하게 사용)
 
-class DeleteGoalViewController: BaseViewController {
+class DeleteGoalViewController: BaseViewController, ViewModelBindableType {
     
     // MARK: - Subviews
     
@@ -21,13 +21,15 @@ class DeleteGoalViewController: BaseViewController {
             $0.askLabel.text = "정말 삭제 하시겠어요?"
             $0.guideLabel.text = "삭제된 목표는 되돌릴 수 없어요 🥺"
             $0.yesButton.setTitle("삭제할게요", for: .normal)
+            $0.yesButton.addTarget(self, action: #selector(deleteGoal), for: .touchUpInside)
             $0.noButton.setTitle("지금 안할래요", for: .normal)
             $0.noButton.addTarget(self, action: #selector(dismissViewController), for: .touchUpInside)
         }
     
     // MARK: - Properties
     
-    var fromParentGoal = true // 상위 목표 수정인지 세부 목표 수정인지
+    var viewModel: DetailParentViewModel!
+    var fromParentGoal = true // 상위 목표 삭제인지 세부 목표 삭제인지
     
     // MARK: - Functions
     
@@ -56,5 +58,18 @@ class DeleteGoalViewController: BaseViewController {
     @objc
     private func dismissViewController() {
         self.dismiss(animated: true)
+    }
+    
+    @objc
+    private func deleteGoal() {
+        // 상위 목표 삭제 API 호출
+        if fromParentGoal {
+            viewModel.deleteParentGoal()
+        } else {
+            // TODO: - 하위 목표 삭제 API 호출
+            
+        }
+        // 이 팝업 dismiss
+        dismiss(animated: true)
     }
 }

--- a/Milestone/Milestone/Screens/FillBox/View/DeleteGoalViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/DeleteGoalViewController.swift
@@ -62,6 +62,8 @@ class DeleteGoalViewController: BaseViewController, ViewModelBindableType {
     
     @objc
     private func deleteGoal() {
+        askPopUpView.yesButton.updateButtonState(.press)
+        
         // 상위 목표 삭제 API 호출
         if fromParentGoal {
             viewModel.deleteParentGoal()
@@ -69,10 +71,8 @@ class DeleteGoalViewController: BaseViewController, ViewModelBindableType {
             // TODO: - 하위 목표 삭제 API 호출
             
         }
-        // 이 팝업 dismiss
-        dismiss(animated: true)
         
-        // 상위 목표 상세 화면을 pop 시켜서 홈으로 나가게 함
+        self.dismiss(animated: true)
         self.viewModel?.popDetailParentVC.accept(true)
     }
 }

--- a/Milestone/Milestone/Screens/FillBox/View/DeleteGoalViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/DeleteGoalViewController.swift
@@ -73,6 +73,6 @@ class DeleteGoalViewController: BaseViewController, ViewModelBindableType {
         dismiss(animated: true)
         
         // 상위 목표 상세 화면을 pop 시켜서 홈으로 나가게 함
-        self.viewModel?.isTest.accept(true)
+        self.viewModel?.popDetailParentVC.accept(true)
     }
 }

--- a/Milestone/Milestone/Screens/FillBox/View/DeleteGoalViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/DeleteGoalViewController.swift
@@ -71,5 +71,8 @@ class DeleteGoalViewController: BaseViewController, ViewModelBindableType {
         }
         // 이 팝업 dismiss
         dismiss(animated: true)
+        
+        // 상위 목표 상세 화면을 pop 시켜서 홈으로 나가게 함
+        self.viewModel?.isTest.accept(true)
     }
 }

--- a/Milestone/Milestone/Screens/FillBox/View/DetailParentViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/DetailParentViewController.swift
@@ -171,9 +171,9 @@ class DetailParentViewController: BaseViewController, ViewModelBindableType {
     }
     
     override func bindUI() {
-        viewModel.isTest
-            .subscribe { [self] isTest in
-                if isTest {
+        viewModel.popDetailParentVC
+            .subscribe { [self] popDetailParentVC in
+                if popDetailParentVC {
                     pop()
                     // 현재 스택에 있는 뷰 컨트롤러들을 가져오고, 가장 상위의 뷰 컨트롤러를 제거
 //                    if var viewControllers = navigationController?.viewControllers {

--- a/Milestone/Milestone/Screens/FillBox/View/MoreViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/MoreViewController.swift
@@ -149,6 +149,7 @@ class MoreViewController: BaseViewController, ViewModelBindableType {
         Logger.debugDescription("삭제하기 클릭")
         let deleteGoalPopUp = DeleteGoalViewController()
             .then {
+                $0.viewModel = viewModel
                 $0.modalTransitionStyle = .crossDissolve
                 $0.modalPresentationStyle = .overFullScreen
             }

--- a/Milestone/Milestone/Screens/FillBox/ViewModel/DetailParentViewModel.swift
+++ b/Milestone/Milestone/Screens/FillBox/ViewModel/DetailParentViewModel.swift
@@ -157,4 +157,22 @@ extension DetailParentViewModel {
             })
             .disposed(by: bag)
     }
+    
+    /// 상위 목표 삭제
+    func deleteParentGoal() {
+        var deleteParentGoalResponse: Observable<Result<EmptyDataModel, APIError>> {
+            requestDeleteParentGoal(id: selectedParentGoal?.identity ?? 0)
+        }
+        
+        deleteParentGoalResponse
+            .subscribe(onNext: { result in
+                switch result {
+                case .success(let response):
+                    Logger.debugDescription(response)
+                case .failure(let error):
+                    Logger.debugDescription(error)
+                }
+            })
+            .disposed(by: bag)
+    }
 }

--- a/Milestone/Milestone/Screens/FillBox/ViewModel/DetailParentViewModel.swift
+++ b/Milestone/Milestone/Screens/FillBox/ViewModel/DetailParentViewModel.swift
@@ -32,7 +32,7 @@ class DetailParentViewModel: BindableViewModel, ServicesGoalList, ServicesDetail
     
     // MARK: - Output
     
-    var isTest = BehaviorRelay(value: false)
+    var popDetailParentVC = BehaviorRelay(value: false)
     var detailGoalList = BehaviorRelay<[DetailGoal]>(value: [])
     var test = BehaviorRelay<[DetailGoal]>(value: [])
     // detailGoalList를 정렬한, 테이블뷰에 보여줄 데이터

--- a/Milestone/Milestone/Screens/StorageBox/View/ResetGoalViewController.swift
+++ b/Milestone/Milestone/Screens/StorageBox/View/ResetGoalViewController.swift
@@ -105,7 +105,7 @@ class ResetGoalViewController: BaseViewController {
         updateButtonState(.press)
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
             self.dismiss(animated: true)
-            self.viewModel?.isTest.accept(true)
+            self.viewModel?.popDetailParentVC.accept(true)
         }
     }
 }


### PR DESCRIPTION
## 상세 내용
- #130
- 상위 목표 삭제 API 연동 및 삭제 완료 후 화면 전환 구현
- 옵저버블을 통해 `DetailGoalViewController`를 `pop` 하는 기능 구현하였다.

## 셀프 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩 컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 오른쪽의 Development에서 이슈와 연결하였는가?
