### PR TITLE
[#136] 설정화면 구현 및 401 에러 retry & adapt 함수 구현

### DIFF
--- a/Milestone/Milestone.xcodeproj/project.pbxproj
+++ b/Milestone/Milestone.xcodeproj/project.pbxproj
@@ -244,6 +244,9 @@
 		C95A3CA12A94EB580028B4ED /* RewardToImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C95A3CA02A94EB580028B4ED /* RewardToImage.swift */; };
 		C95A3CA32A95973B0028B4ED /* Retrospect.swift in Sources */ = {isa = PBXBuildFile; fileRef = C95A3CA22A95973B0028B4ED /* Retrospect.swift */; };
 		C95A3CA52A959A090028B4ED /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C95A3CA42A959A090028B4ED /* LoadingView.swift */; };
+		C968F8ED2A98F1BD0051DE48 /* PrivacyInformationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C968F8EC2A98F1BD0051DE48 /* PrivacyInformationViewController.swift */; };
+		C968F8F52A98F3080051DE48 /* InformationLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C968F8F42A98F3080051DE48 /* InformationLabel.swift */; };
+		C968F8F72A98F3790051DE48 /* InformationBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = C968F8F62A98F3790051DE48 /* InformationBox.swift */; };
 		C9798ACA2A939F9600B5CC4A /* BindableViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9798AC92A939F9600B5CC4A /* BindableViewModel.swift */; };
 		C9798ACC2A939F9E00B5CC4A /* Lodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9798ACB2A939F9E00B5CC4A /* Lodable.swift */; };
 		C9B2CDD62A8A77F1006289A8 /* CompletionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B2CDD52A8A77F1006289A8 /* CompletionViewModel.swift */; };
@@ -407,6 +410,9 @@
 		C95A3CA02A94EB580028B4ED /* RewardToImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardToImage.swift; sourceTree = "<group>"; };
 		C95A3CA22A95973B0028B4ED /* Retrospect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Retrospect.swift; sourceTree = "<group>"; };
 		C95A3CA42A959A090028B4ED /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
+		C968F8EC2A98F1BD0051DE48 /* PrivacyInformationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyInformationViewController.swift; sourceTree = "<group>"; };
+		C968F8F42A98F3080051DE48 /* InformationLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InformationLabel.swift; sourceTree = "<group>"; };
+		C968F8F62A98F3790051DE48 /* InformationBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InformationBox.swift; sourceTree = "<group>"; };
 		C9798AC92A939F9600B5CC4A /* BindableViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BindableViewModel.swift; path = Foundation/BindableViewModel.swift; sourceTree = "<group>"; };
 		C9798ACB2A939F9E00B5CC4A /* Lodable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Lodable.swift; path = Foundation/Lodable.swift; sourceTree = "<group>"; };
 		C9B2CDD52A8A77F1006289A8 /* CompletionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionViewModel.swift; sourceTree = "<group>"; };
@@ -592,6 +598,7 @@
 				A289D9562A912E8F005B7F00 /* Main */,
 				A289D9572A912EB4005B7F00 /* FillBox */,
 				A289D9592A912F6E005B7F00 /* CompletionBox */,
+				C968F8F32A98F2AE0051DE48 /* Setting */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -873,6 +880,15 @@
 			path = ViewModel;
 			sourceTree = "<group>";
 		};
+		C968F8F32A98F2AE0051DE48 /* Setting */ = {
+			isa = PBXGroup;
+			children = (
+				C968F8F42A98F3080051DE48 /* InformationLabel.swift */,
+				C968F8F62A98F3790051DE48 /* InformationBox.swift */,
+			);
+			path = Setting;
+			sourceTree = "<group>";
+		};
 		C9798AC72A939F4A00B5CC4A /* Recovered References */ = {
 			isa = PBXGroup;
 			children = (
@@ -959,6 +975,7 @@
 			children = (
 				C9BF3FC82A97836F0074E781 /* Cell */,
 				C9BF3FC62A97817C0074E781 /* SettingViewController.swift */,
+				C968F8EC2A98F1BD0051DE48 /* PrivacyInformationViewController.swift */,
 			);
 			path = Setting;
 			sourceTree = "<group>";
@@ -1183,6 +1200,7 @@
 				A289D9522A912864005B7F00 /* PointTextStyle.swift in Sources */,
 				C90DC9862A88F0B100241B7C /* UITextField+.swift in Sources */,
 				C90DC9762A876F5D00241B7C /* AppCoordinator.swift in Sources */,
+				C968F8ED2A98F1BD0051DE48 /* PrivacyInformationViewController.swift in Sources */,
 				88216FC02A85328900FE3A77 /* LoginViewController.swift in Sources */,
 				A2C98F062A8B6122009B5579 /* EnterGoalTitleView.swift in Sources */,
 				A2B969872A85875A00C4903F /* ParentGoalTableViewCell.swift in Sources */,
@@ -1212,6 +1230,7 @@
 				A2B969822A85750600C4903F /* MainViewController.swift in Sources */,
 				A22774AD2A977438004AE5D7 /* AMPMStyle.swift in Sources */,
 				C9B2CE102A8F4F9A006289A8 /* Constants.swift in Sources */,
+				C968F8F72A98F3790051DE48 /* InformationBox.swift in Sources */,
 				A2FA59192A7FD2CF006ACA2E /* BaseViewController.swift in Sources */,
 				C9B2CE222A8F672C006289A8 /* ServicesUser.swift in Sources */,
 				C9BF3FC72A97817C0074E781 /* SettingViewController.swift in Sources */,
@@ -1234,6 +1253,7 @@
 				C9BF3FCA2A97837C0074E781 /* SettingTableViewCellFirstSection.swift in Sources */,
 				C90DC97A2A88814700241B7C /* Coordinator.swift in Sources */,
 				A2B969822A85750600C4903F /* MainViewController.swift in Sources */,
+				C968F8F52A98F3080051DE48 /* InformationLabel.swift in Sources */,
 				A282DA522A94BB2400A0D0BF /* DetailParentViewModel.swift in Sources */,
 				C9B2CE052A8E645D006289A8 /* CompletionSavedReviewWithoutGuideViewController.swift in Sources */,
 				A2C98F022A8B6117009B5579 /* AddParentGoalViewController.swift in Sources */,

--- a/Milestone/Milestone/Core/API/APIInterceptor.swift
+++ b/Milestone/Milestone/Core/API/APIInterceptor.swift
@@ -5,12 +5,14 @@
 //  Created by 박경준 on 2023/08/22.
 //
 
-import Foundation
+import UIKit
 
 import Alamofire
 import RxSwift
 
 class APIInterceptor: RequestInterceptor {
+    let disposeBag = DisposeBag()
+    
     func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {
         
         if checkIsRegisterAPI(urlRequest: urlRequest) {
@@ -27,10 +29,51 @@ class APIInterceptor: RequestInterceptor {
         
         completion(.success(urlRequest))
     }
-
-//    func retry(_ request: Request, for session: Session, dueTo error: Error, completion: @escaping (RetryResult) -> Void) {
-//        <#code#>
-//    }
+    
+    func retry(_ request: Request, for session: Session, dueTo error: Error, completion: @escaping (RetryResult) -> Void) {
+        guard let response = request.task?.response as? HTTPURLResponse, response.statusCode == 401 else {
+            completion(.doNotRetryWithError(error))
+            return
+        }
+        
+        if let url = request.response?.url {
+            if url.relativePath == "/reissue" {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                    
+                    let window = UIApplication.shared.connectedScenes.compactMap { ($0 as? UIWindowScene)?.keyWindow }.last
+                    let root = window?.rootViewController
+//                    LoginCoordinator(navigationController: root as! UINavigationController)
+                    AppCoordinator(window: window!).start()
+                }
+                
+                completion(.doNotRetryWithError(APIError.http(status: 401)))
+            } else {
+                APIRefreshTask().requestRefreshToken()
+                    .subscribe(onNext: {[unowned self] result in
+                        switch result {
+                        case .success(let response):
+                            KeychainManager.shared.rx.saveItem(response.data.accessToken, itemClass: .password, key: KeychainKeyList.accessToken.rawValue)
+                                .subscribe(onNext: {
+                                    print("accessToken save completed!")
+                                })
+                                .disposed(by: self.disposeBag)
+                            KeychainManager.shared.rx.saveItem(response.data.refreshToken, itemClass: .password, key: KeychainKeyList.refreshToken.rawValue)
+                                .subscribe(onNext: {
+                                    print("refreshToken save completed!")
+                                })
+                                .disposed(by: self.disposeBag)
+                            print("SAVE COMPLETED!")
+                            completion(.retry)
+                        case .failure(let error):
+                            print(error)
+                            completion(.doNotRetry)
+                        }
+                    })
+                    .disposed(by: disposeBag)
+            }
+        }
+       
+    }
     
     func checkIsRegisterAPI(urlRequest: URLRequest) -> Bool {
         if urlRequest.url!.relativePath == "/auth/kakao" || urlRequest.url!.relativePath == "/auth/apple" {
@@ -39,4 +82,8 @@ class APIInterceptor: RequestInterceptor {
             return false
         }
     }
+}
+
+class APIRefreshTask: ServicesUser {
+    var apiSession: APIService = APISession()
 }

--- a/Milestone/Milestone/Core/API/APIInterceptor.swift
+++ b/Milestone/Milestone/Core/API/APIInterceptor.swift
@@ -8,13 +8,35 @@
 import Foundation
 
 import Alamofire
+import RxSwift
 
 class APIInterceptor: RequestInterceptor {
-//    func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {
-//        <#code#>
-//    }
-//    
+    func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {
+        
+        if checkIsRegisterAPI(urlRequest: urlRequest) {
+            completion(.success(urlRequest))
+            return
+        }
+        
+        guard let accessToken: String = try? KeychainManager.shared.retrieveItem(ofClass: .password, key: KeychainKeyList.accessToken.rawValue) else {
+            print("NIL")
+            return
+        }
+        var urlRequest = urlRequest
+        urlRequest.headers.add(.authorization(bearerToken: accessToken))
+        
+        completion(.success(urlRequest))
+    }
+
 //    func retry(_ request: Request, for session: Session, dueTo error: Error, completion: @escaping (RetryResult) -> Void) {
 //        <#code#>
 //    }
+    
+    func checkIsRegisterAPI(urlRequest: URLRequest) -> Bool {
+        if urlRequest.url!.relativePath == "/auth/kakao" || urlRequest.url!.relativePath == "/auth/apple" {
+            return true
+        } else {
+            return false
+        }
+    }
 }

--- a/Milestone/Milestone/Core/API/APIRouter.swift
+++ b/Milestone/Milestone/Core/API/APIRouter.swift
@@ -38,6 +38,9 @@ enum APIRouter: URLRequestConvertible {
     case completeDetailGoal(lowerLevelGoalId: Int) // 하위목표 완료
     case postDetailGoal(higherLevelGoalId: Int, detailGoal: DetailGoalInfo)
     
+    /// 임시
+    case authTest
+    
     // MARK: - HttpMethod
     /// switch - self 구문으로 각 엔드포인트별 메서드 지정
     private var method: HTTPMethod {
@@ -78,6 +81,8 @@ enum APIRouter: URLRequestConvertible {
             return .patch
         case .postDetailGoal:
             return .post
+        case .authTest:
+            return .get
         }
     }
     
@@ -122,6 +127,8 @@ enum APIRouter: URLRequestConvertible {
             return "/detail-goals/\(id)/complete"
         case .postDetailGoal(let id, _):
             return "/goals/\(id)/detail-goals"
+        case .authTest:
+            return "/token"
         }
     }
     
@@ -204,6 +211,8 @@ enum APIRouter: URLRequestConvertible {
                 K.Parameters.alarmTime: detailGoal.alarmTime,
                 K.Parameters.alarmDays: detailGoal.alarmDays
             ]
+        case .authTest:
+            return nil
         }
     }
     

--- a/Milestone/Milestone/Core/API/APISession.swift
+++ b/Milestone/Milestone/Core/API/APISession.swift
@@ -25,7 +25,7 @@ struct APISession: APIService {
         return Observable<Result<T, APIError>>.create { observer in
             
             /// Alamofire 네트워크 요청함수 호출
-            let request = API.session.request(request).responseDecodable { (response: DataResponse<T, AFError>) in
+            let request = API.session.request(request, interceptor: APIInterceptor()).responseDecodable { (response: DataResponse<T, AFError>) in
                 
                 guard let statusCode = response.response?.statusCode else {
                   observer.onNext(.failure(.unknown))

--- a/Milestone/Milestone/Core/Services/ServicesUser.swift
+++ b/Milestone/Milestone/Core/Services/ServicesUser.swift
@@ -9,12 +9,23 @@ import Foundation
 import RxSwift
 
 protocol ServicesUser: Service {
-//    Observable<Result<BaseModel<[Goal]>, APIError>>
     func requestToken(provider: String, userId: String, fcmToken: String) -> Observable<Result<BaseModel<Token>, APIError>>
+    
+    func requestRefreshToken() -> Observable<Result<BaseModel<Token>, APIError>>
+    
+    func authTest() -> Observable<Result<String, APIError>>
 }
 
 extension ServicesUser {
     func requestToken(provider: String, userId: String, fcmToken: String) -> Observable<Result<BaseModel<Token>, APIError>> {
         return apiSession.request(.login(provider: provider, userId: userId, fcmToken: fcmToken))
+    }
+    
+    func requestRefreshToken() -> Observable<Result<BaseModel<Token>, APIError>> {
+        return apiSession.request(.reissue)
+    }
+    
+    func authTest() -> Observable<Result<String, APIError>> {
+        return apiSession.request(.authTest)
     }
 }

--- a/Milestone/Milestone/Global/Component/Setting/InformationBox.swift
+++ b/Milestone/Milestone/Global/Component/Setting/InformationBox.swift
@@ -1,0 +1,50 @@
+//
+//  InformationBox.swift
+//  Milestone
+//
+//  Created by 박경준 on 2023/08/25.
+//
+
+import UIKit
+
+class InformationBox: UIView {
+
+    let titleLabel = InformationLabel()
+        .then {
+            $0.isPrimary = true
+        }
+    
+    let contentsLabel = InformationLabel()
+        .then {
+            $0.numberOfLines = 0
+            $0.isPrimary = false
+        }
+
+    // MARK: Life Cycles
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        render()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func render() {
+        self.addSubViews([titleLabel, contentsLabel])
+        
+        titleLabel.snp.makeConstraints { make in
+            make.top.equalToSuperview()
+            make.leading.equalToSuperview()
+            make.trailing.equalToSuperview()
+        }
+        
+        contentsLabel.snp.makeConstraints { make in
+            make.top.equalTo(titleLabel.snp.bottom)
+            make.leading.equalToSuperview()
+            make.trailing.equalToSuperview()
+        }
+    }
+}

--- a/Milestone/Milestone/Global/Component/Setting/InformationLabel.swift
+++ b/Milestone/Milestone/Global/Component/Setting/InformationLabel.swift
@@ -1,0 +1,21 @@
+//
+//  InformationLabel.swift
+//  Milestone
+//
+//  Created by 박경준 on 2023/08/25.
+//
+
+import UIKit
+
+class InformationLabel: UILabel {
+
+    var isPrimary = false {
+        didSet {
+            if isPrimary {
+                self.font = .pretendard(.semibold, ofSize: 14)
+            } else {
+                self.font = .pretendard(.regular, ofSize: 14)
+            }
+        }
+    }
+}

--- a/Milestone/Milestone/Global/Support/AppCoordinator.swift
+++ b/Milestone/Milestone/Global/Support/AppCoordinator.swift
@@ -26,15 +26,7 @@ class AppCoordinator: Coordinator {
         window.makeKeyAndVisible()
         
         // FIXME: 실물기기 테스트 진행 가능시 아래 주석처리 코드로 수정할것!
-        navigationController.pushViewController(MainViewController(), animated: true)
         
-//        coordinate(to: LoginCoordinator(navigationController: navigationController))
-        
-//        if AuthApi.hasToken() {
-//            navigationController.pushViewController(MainViewController(), animated: true)
-//        } else {
-//            let startCoordinator = LoginCoordinator(navigationController: navigationController)
-//            coordinate(to: startCoordinator)
-//        }
+        coordinate(to: LoginCoordinator(navigationController: navigationController))
     }
 }

--- a/Milestone/Milestone/Screens/CompletionBox/View/CompletionBoxViewController.swift
+++ b/Milestone/Milestone/Screens/CompletionBox/View/CompletionBoxViewController.swift
@@ -83,6 +83,21 @@ class CompletionBoxViewController: BaseViewController, ViewModelBindableType {
             .disposed(by: disposeBag)
         
         checkFirstCompletionBox()
+        
+        
+        // FIXME: - 테스트코드
+//        viewModel.authTestResponse
+//            .subscribe(onNext: { result in
+//                switch result {
+//                case .success(let str):
+//                    print("SUCC!!")
+//                    print(str)
+//                case .failure(let error):
+//                    print("ERR!!")
+//                    print(error)
+//                }
+//            })
+//            .disposed(by: disposeBag)
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -128,7 +143,8 @@ class CompletionBoxViewController: BaseViewController, ViewModelBindableType {
     
     func bindViewModel() {
         viewModel.goalData
-            .bind(to: tableView.rx.items(cellIdentifier: CompletionTableViewCell.identifier, cellType: CompletionTableViewCell.self)) { [unowned self] row, element, cell in
+            .bind(to: tableView.rx.items(cellIdentifier: CompletionTableViewCell.identifier, cellType: CompletionTableViewCell.self)) { [weak self] row, element, cell in
+                guard let self = self else { return }
                 let startDate = dateFormatter.date(from: element.startDate)!
                 let endDate = dateFormatter.date(from: element.endDate)!
                 cell.dateLabel.text = dateFormatter.string(from: startDate) + " - " + dateFormatter.string(from: endDate)
@@ -258,6 +274,10 @@ class CompletionBoxViewController: BaseViewController, ViewModelBindableType {
         pushViewDisposables.forEach { disposable in
             disposable.dispose()
         }
+    }
+    
+    deinit {
+        disposeBag = DisposeBag()
     }
 }
 

--- a/Milestone/Milestone/Screens/CompletionBox/ViewModel/CompletionViewModel.swift
+++ b/Milestone/Milestone/Screens/CompletionBox/ViewModel/CompletionViewModel.swift
@@ -26,6 +26,11 @@ class CompletionViewModel: BindableViewModel {
         requestEnabledRetrospectCount()
     }
     
+    // FIXME: - 테스트코드
+    var authTestResponse: Observable<Result<String, APIError>> {
+        authTest()
+    }
+    
     var goalData = BehaviorRelay<[ParentGoal]>(value: [])
 
     var goalDataCount = PublishRelay<Int>()
@@ -43,7 +48,7 @@ class CompletionViewModel: BindableViewModel {
 }
 
 /// output
-extension CompletionViewModel: ServicesGoalList { }
+extension CompletionViewModel: ServicesGoalList, ServicesUser { }
 
 extension CompletionViewModel {
     func retrieveGoalData() {

--- a/Milestone/Milestone/Screens/Onboarding/View/LoginViewController.swift
+++ b/Milestone/Milestone/Screens/Onboarding/View/LoginViewController.swift
@@ -68,10 +68,10 @@ class LoginViewController: BaseViewController {
     
     let appleLoginButton: UIButton = {
         let btn = UIButton(type: .system)
-        btn.setTitle("Continue with Apple", for: .normal)
+        btn.setTitle("Apple로 로그인", for: .normal)
         btn.backgroundColor = UIColor(hex: "#050708")
         btn.setTitleColor(.white, for: .normal)
-        btn.titleLabel?.font = UIFont(name: "SFProDisplay-Medium", size: 19)
+        btn.titleLabel?.font = UIFont(name: "AppleSDGothicNeo-Medium", size: 19)
         btn.titleLabel?.textAlignment = .right
         btn.layer.cornerRadius = 8
         return btn
@@ -85,12 +85,11 @@ class LoginViewController: BaseViewController {
     
     let kakaoLoginButton: UIButton = {
         let btn = UIButton(type: .system)
-        btn.setTitle("Login With Kakao", for: .normal)
+        btn.setTitle("카카오로 로그인", for: .normal)
         btn.backgroundColor = UIColor(hex: "#FEE500")
         btn.setTitleColor(.black, for: .normal)
         btn.titleLabel?.font = UIFont(name: "AppleSDGothicNeo-SemiBold", size: 19)
         btn.layer.cornerRadius = 8
-//        btn.addTarget(self, action: #selector(kakaoButtonTapped), for: .touchUpInside)
         return btn
     }()
     

--- a/Milestone/Milestone/Screens/Onboarding/ViewModel/OnboardingViewModel.swift
+++ b/Milestone/Milestone/Screens/Onboarding/ViewModel/OnboardingViewModel.swift
@@ -53,14 +53,29 @@ class OnboardingViewModel: BindableViewModel {
                 .map {
                     KeychainManager.shared.rx
                         .saveItem($0.accessToken, itemClass: .password, key: KeychainKeyList.accessToken.rawValue)
-                },
+                }
+                .subscribe(onNext: {
+                    $0.subscribe(onCompleted: {
+                        print("completed")
+                    })
+                    .dispose()
+                })
+            ,
             tokenSubject
                 .map {
                     KeychainManager.shared.rx
                         .saveItem($0.refreshToken, itemClass: .password, key: KeychainKeyList.refreshToken.rawValue)
+                }
+                .subscribe(onNext: {
+                    $0.subscribe(onCompleted: {
+                        print("completed2")
+                    })
+                    .dispose()
                 })
+        )
         
-        Observable.merge(mergedObservable)
+        Observable<any Disposable>
+            .merge()
             .subscribe(onCompleted: { [weak self] in
                 guard let self = self else { return }
                 self.loginCoordinator?.coordinateToOnboarding()

--- a/Milestone/Milestone/Screens/Setting/PrivacyInformationViewController.swift
+++ b/Milestone/Milestone/Screens/Setting/PrivacyInformationViewController.swift
@@ -1,0 +1,179 @@
+//
+//  PrivacyInformationViewController.swift
+//  Milestone
+//
+//  Created by 박경준 on 2023/08/25.
+//
+
+import UIKit
+
+class PrivacyInformationViewController: BaseViewController {
+
+    // MARK: - Subviews
+    
+    lazy var leftBarButton = UIBarButtonItem()
+        .then {
+            $0.image = UIImage(systemName: "chevron.left")
+            $0.style = .plain
+            $0.tintColor = .gray05
+            $0.target = self
+            $0.action = #selector(pop)
+        }
+    
+    let scrollView = UIScrollView()
+        .then { sv in
+            let view = UIView()
+            sv.addSubview(view)
+            view.snp.makeConstraints {
+                $0.top.equalTo(sv.contentLayoutGuide.snp.top)
+                $0.leading.equalTo(sv.contentLayoutGuide.snp.leading)
+                $0.trailing.equalTo(sv.contentLayoutGuide.snp.trailing)
+                $0.bottom.equalTo(sv.contentLayoutGuide.snp.bottom)
+
+                $0.leading.equalTo(sv.frameLayoutGuide.snp.leading)
+                $0.trailing.equalTo(sv.frameLayoutGuide.snp.trailing)
+                $0.height.equalTo(sv.frameLayoutGuide.snp.height).priority(.low)
+            }
+        }
+    
+    let firstContent = InformationBox()
+        .then {
+            $0.contentsLabel.text = "개인정보 처리방침은 MileStone(이하 \"회사\"라 합니다)이 특정한 가입절차를 거친 이용자들만 이용 가능한 폐쇄형 서비스를 제공함에 있어, 개인정보를 어떻게 수집·이용·보관·파기하는지에 대한 정보를 담은 방침을 의미합니다. 개인정보 처리방침은 개인정보보호법 등 국내 개인정보 보호 법령을 모두 준수하고 있습니다. 본 개인정보 처리방침에서 정하지 않은 용어의 정의는 서비스 이용약관을 따릅니다."
+            $0.titleLabel.text = "1. 개인정보 처리방침"
+        }
+    
+    let secondContent = InformationBox()
+        .then {
+            $0.contentsLabel.text = "회사는 서비스 제공을 위해 다음 항목 중 최소한의 개인정보를 수집합니다."
+            $0.titleLabel.text = "2. 수집하는 개인정보의 항목"
+        }
+    
+    let secondOneContent = InformationLabel()
+        .then {
+            $0.numberOfLines = 0
+            $0.isPrimary = false
+            $0.text = "1) 회원가입 시 수집되는 개인정보\n닉네임"
+        }
+    
+    let secondTwoContent = InformationLabel()
+        .then {
+            $0.text = "2) 수집한 개인정보의 처리 목적\n수집된 개인정보는 다음의 목적에 한해 이용됩니다.\n1. 가입 및 탈퇴 의사 확인, 회원 식별 등 회원 관리\n2. 서비스 제공 및 기존·신규 시스템 개발·유지·개선\n3. 문의·제휴·광고·이벤트·게시 관련 요청 응대 및 처리"
+            $0.isPrimary = false
+            $0.numberOfLines = 0
+        }
+    
+    let thirdContent = InformationBox()
+        .then {
+            $0.contentsLabel.text = "회사는 회원의 개인정보를 제3자에게 제공하지 않습니다. 단, 다음의 사유가 있을 경우 제공할 수 있습니다. \n1. 회원이 제휴사의 서비스를 이용하기 위해 개인정보 제공을 회사에 요청할 경우 \n2. 관련법에 따른 규정에 의한 경우 \n3. 이용자의 생명이나 안전에 급박한 위험이 확인되어 이를 해소하기 위한 경우\n4. 영업의 양수 등"
+            $0.titleLabel.text = "3. 개인정보의 제3자 제공"
+        }
+    
+    let fourthContent = InformationBox()
+        .then {
+            $0.contentsLabel.text = "회사는 원활한 개인정보 업무처리와 보안성 높은 서비스 제공을 위하여, 신뢰도가 검증된 다음 회사 및 서비스에 개인정보 관련 업무 처리를 위탁하고 있습니다. 위탁계약 체결 시 회사는 기술적·관리적 보호조치 등 수탁자에 대한 관리·감독을 하고 있습니다.\n1. Amazon Web Services, Inc. : 서비스 시스템 제공, 데이터 관리 및 보관\n2. Apple : 회원 관리, 운영 시스템 지원\n3. Kakao : 회원 관리, 운영 시스템 지원"
+            $0.titleLabel.text = "4. 개인정보 처리의 위탁"
+        }
+    
+    let fifthContent = InformationBox()
+        .then {
+            $0.contentsLabel.text = "회사는 서비스를 제공하는 동안 개인정보 처리방침 및 관련법에 의거하여 회원의 개인정보를 지속적으로 관리 및 보관합니다. 탈퇴 등 개인정보 수집 및 이용목적이 달성될 경우, 수집된 개인정보는 즉시 또는 다음과 같이 일정 기간 이후 파기됩니다.\n1. 가입 시 수집된 개인정보 : 탈퇴 후 14일\n2. 제휴·광고·이벤트 관련 요청 응대 및 처리 자료 : 3개월\n3. 기기 정보 및 로그 기록 : 최대 1년\n4. 문의 및 응대 기록 : 3년\n ※ 위 항에도 불구하고 법령에 의해 개인정보를 보존해야 하는 경우, 해당 개인정보는 물리적·논리적으로 분리하여 해당 법령에서 정한 기간에 따라 저장합니다.※ 회원 탈퇴, 보관 기한 만료 등 파기 사유가 발생한 개인정보는 재생이 불가능한 방법으로 파기됩니다. 전자적 파일 형태로 기록·저장된 개인정보는 기록을 재생할 수 없도록 파기하며, 종이 문서에 기록·저장된 개인정보는 분쇄기로 분쇄하거나 소각하여 파기합니다.※ 회원이 1년 이상 로그인 및 접속을 하지 않을 경우, 해당 계정은 휴면 계정으로 전환됩니다. 개인정보의 안전한 처리를 위해 닉네임 정보는 분리 보관되며, 이외의 개인정보 및 이용기록은 모두 파기될 수 있습니다. 휴면 계정이 로그인에 성공할 경우, 휴면 상태가 즉시 해제되어 모든 서비스를 이용할 수 있습니다. 휴면 계정 전환 이후에도 3년 동안 로그인을 하지 않을 경우, 해당 계정은 영구 삭제됩니다."
+            $0.titleLabel.text = "5. 수집한 개인정보의 보관 및 파기"
+        }
+    
+    let sixthContent = InformationBox()
+        .then {
+            $0.contentsLabel.text = "회원은 언제든지 MileStone팀 이메일 (rudwns3927@gmail.com)을 통해 자신의 개인정보를 조회하거나 수정, 삭제, 탈퇴를 할 수 있습니다."
+            $0.titleLabel.text = "6. 정보주체의 권리, 의무 및 행사"
+        }
+    
+    let seventhContent = InformationBox()
+        .then {
+            $0.contentsLabel.text = "회사는 회원의 개인정보를 최선으로 보호하고 관련된 불만을 처리하기 위해 최선의 노력을 다하고 있습니다.\n1. 개인정보보호 담당 부서 : MileStone 서버 팀\n2. MileStone 팀 이메일 : rudwns3927@gmail.com\n※ 서비스 이용, 접근 제한 등의 문의는 위 창구를 통해 처리되지 않습니다. 해당 문의는 MileStone 이메일 (rudwns3927@gmail.com)을 통해 전달해주시기 바랍니다. 기타 개인정보 침해에 대한 신고나 상담이 필요하신 경우에는 다음 기관에 문의하시기 바랍니다. \n1. 개인정보 분쟁조정위원회 : https://www.kopico.go.kr\n2. 사이버범죄 신고시스템 : https://ecrm.police.go.kr"
+            $0.titleLabel.text = "7. 개인정보에 관한 책임자 및 서비스"
+        }
+    
+    let eighthContent = InformationBox()
+        .then {
+            $0.contentsLabel.text = "이 개인정보 처리방침은 2023년 8월 25일에 개정되었습니다."
+            $0.titleLabel.text = "8. 기타"
+        }
+    
+    // MARK: - Functions
+    override func render() {
+        view.addSubview(scrollView)
+        scrollView.subviews.first!.addSubViews([firstContent, secondContent, secondOneContent, secondTwoContent, thirdContent, fourthContent, fifthContent, sixthContent, seventhContent, eighthContent])
+        
+        scrollView.snp.makeConstraints { make in
+            make.edges.equalTo(view)
+        }
+        
+        firstContent.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(32)
+            make.leading.equalToSuperview().offset(24)
+            make.trailing.equalToSuperview().offset(-24)
+        }
+        
+        secondContent.snp.makeConstraints { make in
+            make.top.equalTo(firstContent.contentsLabel.snp.bottom).offset(24)
+            make.leading.equalToSuperview().offset(24)
+            make.trailing.equalToSuperview().offset(-24)
+        }
+        
+        secondOneContent.snp.makeConstraints { make in
+            make.top.equalTo(secondContent.contentsLabel.snp.bottom).offset(24)
+            make.leading.equalTo(secondContent)
+            make.trailing.equalToSuperview().offset(-24)
+        }
+        
+        secondTwoContent.snp.makeConstraints { make in
+            make.top.equalTo(secondOneContent.snp.bottom).offset(24)
+            make.leading.equalTo(secondContent)
+            make.trailing.equalToSuperview().offset(-24)
+        }
+        
+        thirdContent.snp.makeConstraints { make in
+            make.top.equalTo(secondTwoContent.snp.bottom).offset(24)
+            make.leading.equalTo(secondTwoContent)
+            make.trailing.equalToSuperview().offset(-24)
+        }
+        
+        fourthContent.snp.makeConstraints { make in
+            make.top.equalTo(thirdContent.contentsLabel.snp.bottom).offset(24)
+            make.leading.equalTo(thirdContent)
+            make.trailing.equalToSuperview().offset(-24)
+        }
+        
+        fifthContent.snp.makeConstraints { make in
+            make.top.equalTo(fourthContent.contentsLabel.snp.bottom).offset(24)
+            make.leading.equalTo(fourthContent)
+            make.trailing.equalToSuperview().offset(-24)
+        }
+        
+        sixthContent.snp.makeConstraints { make in
+            make.top.equalTo(fifthContent.contentsLabel.snp.bottom).offset(24)
+            make.leading.equalTo(fifthContent)
+            make.trailing.equalToSuperview().offset(-24)
+        }
+        
+        seventhContent.snp.makeConstraints { make in
+            make.top.equalTo(sixthContent.contentsLabel.snp.bottom).offset(24)
+            make.leading.equalTo(sixthContent)
+            make.trailing.equalToSuperview().offset(-24)
+        }
+        
+        eighthContent.snp.makeConstraints { make in
+            make.top.equalTo(seventhContent.contentsLabel.snp.bottom).offset(24)
+            make.leading.equalTo(seventhContent)
+            make.trailing.equalToSuperview().offset(-48)
+            make.height.equalTo(42)
+            make.bottom.equalTo(scrollView.snp.bottom).offset(-16)
+        }
+    }
+    
+    override func configUI() {
+        self.navigationItem.leftBarButtonItem = leftBarButton
+        view.backgroundColor = .white
+        self.title = "개인정보 처리 방침"
+        self.navigationController?.navigationBar.prefersLargeTitles = true
+    }
+}

--- a/Milestone/Milestone/Screens/Setting/SettingViewController.swift
+++ b/Milestone/Milestone/Screens/Setting/SettingViewController.swift
@@ -139,20 +139,14 @@ extension SettingViewController: UITableViewDataSource {
             return UITableViewCell()
         }
     }
-    
-    private func checkNotificationRegistered() {
-        if UserDefaults.standard.bool(forKey: UserDefaultsKeyStyle.registerNotification.rawValue) {
-            UIApplication.shared.registerForRemoteNotifications()
-        } else {
-            
-        }
-    }
 }
 
 extension SettingViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         if indexPath.section == 1 {
-            if indexPath.row == 1 {
+            if indexPath.row == 0 {
+                self.navigationController?.pushViewController(PrivacyInformationViewController(), animated: true)
+            } else if indexPath.row == 1 {
                 modalViewController.askPopUpView.askLabel.text = "로그아웃 하시겠어요?"
                 modalViewController.askPopUpView.guideLabel.text = "다시 오시길 기다릴게요 🥺"
                 


### PR DESCRIPTION
## 상세 내용

1. statusCode 401인 경우 API 재요청 - url pathComponent을 기준으로 토큰 리프레시를 요청하는 API에서 401이 발생했다는 의미는 현재 보유중인 리프레시 토큰이 만료되었다는 뜻으로 판단하여 메인 뷰로 이동하도록 로직 구현
2. 이때 `UIApplication.shared.connectedScenes.compactMap { ($0 as? UIWindowScene)?.keyWindow }.last` 코드를 사용하면 뷰 컨트롤러를 상속받지 않는 외부 클래스에서도 window속성에 접근하여 루트 뷰컨으로 이동할 수 있게됨
3. 앱 코디네이터에 window 네비게이션 뷰 컨트롤러를 전달하여 화면을 이동

## 주의

1. 테이블뷰 datasource 커스텀 정의시 메모리 해제를 제때 시켜주지 않아 루트 뷰컨으로 이동되는 시점에 앱에 크래시가 발생
2. deinit 소멸자 함수를 구현하여 데이터소스 nil로 재할당 진행하였음

<br/>

## 셀프 체크리스트
- [ ] Merge 하는 브랜치가 올바른가?
- [ ] 코딩 컨벤션을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 오른쪽의 Development에서 이슈와 연결하였는가?
