### PR TITLE
[#144] 상위 목표가 완료되는 시점에 목표 완료 팝업 뷰 띄우기

### DIFF
--- a/Milestone/Milestone.xcodeproj/project.pbxproj
+++ b/Milestone/Milestone.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 		A28EDA192A879565001A021A /* DetailParentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A28EDA182A879565001A021A /* DetailParentViewController.swift */; };
 		A28EDA1A2A879565001A021A /* DetailParentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A28EDA182A879565001A021A /* DetailParentViewController.swift */; };
 		A28EDA1B2A879565001A021A /* DetailParentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A28EDA182A879565001A021A /* DetailParentViewController.swift */; };
+		A298E9592A9968B000EC0067 /* JewelPopUpImageStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A298E9582A9968B000EC0067 /* JewelPopUpImageStyle.swift */; };
 		A2B20D442A7E3EA1001ED73C /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = A2B20D432A7E3EA1001ED73C /* Moya */; };
 		A2B20D462A7E3EA1001ED73C /* RxMoya in Frameworks */ = {isa = PBXBuildFile; productRef = A2B20D452A7E3EA1001ED73C /* RxMoya */; };
 		A2B20D492A7E3EC6001ED73C /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = A2B20D482A7E3EC6001ED73C /* Then */; };
@@ -335,6 +336,7 @@
 		A28EDA102A87808A001A021A /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
 		A28EDA142A8791F7001A021A /* DetailGoalCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailGoalCollectionViewCell.swift; sourceTree = "<group>"; };
 		A28EDA182A879565001A021A /* DetailParentViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetailParentViewController.swift; sourceTree = "<group>"; };
+		A298E9582A9968B000EC0067 /* JewelPopUpImageStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JewelPopUpImageStyle.swift; sourceTree = "<group>"; };
 		A2B20D582A7E4E5C001ED73C /* UIFont+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+.swift"; sourceTree = "<group>"; };
 		A2B20D5C2A7E4E68001ED73C /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		A2B20D602A7E4FAD001ED73C /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
@@ -575,6 +577,7 @@
 				C9B2CE462A92F61D006289A8 /* GoalStatusParameter.swift */,
 				C9040FD72A93CE7D00270E94 /* KeychainKeyList.swift */,
 				C95A3CA02A94EB580028B4ED /* RewardToImage.swift */,
+				A298E9582A9968B000EC0067 /* JewelPopUpImageStyle.swift */,
 			);
 			path = Enum;
 			sourceTree = "<group>";
@@ -1217,6 +1220,7 @@
 				C968F8F72A98F3790051DE48 /* InformationBox.swift in Sources */,
 				A2FA59192A7FD2CF006ACA2E /* BaseViewController.swift in Sources */,
 				C9B2CE222A8F672C006289A8 /* ServicesUser.swift in Sources */,
+				A298E9592A9968B000EC0067 /* JewelPopUpImageStyle.swift in Sources */,
 				C9BF3FC72A97817C0074E781 /* SettingViewController.swift in Sources */,
 				A27C9A102A8E42B5002C6F44 /* EnterGoalAlarmView.swift in Sources */,
 				A289D94A2A912616005B7F00 /* WriteRetrospectStyle.swift in Sources */,

--- a/Milestone/Milestone/Global/Enum/JewelPopUpImageStyle.swift
+++ b/Milestone/Milestone/Global/Enum/JewelPopUpImageStyle.swift
@@ -1,0 +1,37 @@
+//
+//  JewelPopUpImageStyle.swift
+//  Milestone
+//
+//  Created by 서은수 on 2023/08/26.
+//
+
+import UIKit
+
+// MARK: - 보석 이미지와 팝업 이미지 이름을 매칭
+
+enum JewelPopUpImageStyle: String {
+    case blueStonePopUpVer1 = "BLUE_JEWEL_1"
+    case blueStonePopUpVer2 = "BLUE_JEWEL_2"
+    case blueStonePopUpVer3 = "BLUE_JEWEL_3"
+    case blueStonePopUpVer4 = "BLUE_JEWEL_4"
+    case blueStonePopUpVer5 = "BLUE_JEWEL_5"
+    case purpleStonePopUpVer1 = "PURPLE_JEWEL_1"
+    case purpleStonePopUpVer2 = "PURPLE_JEWEL_2"
+    case purpleStonePopUpVer3 = "PURPLE_JEWEL_3"
+    case purpleStonePopUpVer4 = "PURPLE_JEWEL_4"
+    case purpleStonePopUpVer5 = "PURPLE_JEWEL_5"
+    case pinkStonePopUpVer1 = "PINK_JEWEL_1"
+    case pinkStonePopUpVer2 = "PINK_JEWEL_2"
+    case pinkStonePopUpVer3 = "PINK_JEWEL_3"
+    case pinkStonePopUpVer4 = "PINK_JEWEL_4"
+    case pinkStonePopUpVer5 = "PINK_JEWEL_5"
+    case greenStonePopUpVer1 = "GREEN_JEWEL_1"
+    case greenStonePopUpVer2 = "GREEN_JEWEL_2"
+    case greenStonePopUpVer3 = "GREEN_JEWEL_3"
+    case greenStonePopUpVer4 = "GREEN_JEWEL_4"
+    case greenStonePopUpVer5 = "GREEN_JEWEL_5"
+    
+    var caseString: String {
+        String(describing: self)
+    }
+}

--- a/Milestone/Milestone/Screens/FillBox/View/CompleteGoalViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/CompleteGoalViewController.swift
@@ -31,6 +31,10 @@ class CompleteGoalViewController: BaseViewController {
 //            $0.goToButton.addTarget(self, action: #selector(), for: .touchUpInside)
         }
     
+    // MARK: - Properties
+    
+    var viewModel: DetailParentViewModel!
+    
     // MARK: - Life Cycle
     
     override func viewDidLoad() {
@@ -59,6 +63,10 @@ class CompleteGoalViewController: BaseViewController {
     
     override func configUI() {
         view.backgroundColor = UIColor.init(hex: "#000000").withAlphaComponent(0.3)
+        
+        let value = viewModel.completedGoalResult.value
+        completePopUpView.alertImageView.image = UIImage(named: JewelPopUpImageStyle(rawValue: value.rewardType ?? "BLUE_JEWEL_1")?.caseString ?? "blueStonePopUpVer1")
+        completePopUpView.completeInformationLabel.text = "\(value.completedGoalCount)번째 보석을 찾으셨네요!"
     }
     
     /// 목표 완료 팝업 뷰가 띄워졌으니 UserDefaults 값을 바꾼다

--- a/Milestone/Milestone/Screens/FillBox/View/DetailParentViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/DetailParentViewController.swift
@@ -100,6 +100,7 @@ class DetailParentViewController: BaseViewController, ViewModelBindableType {
     
     var isFromStorage = false
     var viewModel: DetailParentViewModel!
+    var isParentCompleted: Bool!
     
     // 세부 목표를 추가해주세요! 데이터
     private var emptyGoal: DetailGoal?
@@ -248,6 +249,21 @@ class DetailParentViewController: BaseViewController, ViewModelBindableType {
                 goalTitleLabel.text = goal.title
                 dDayLabel.text = "D - \(goal.dDay)"
                 termLabel.text = "\(goal.startDate) - \(goal.endDate)"
+            })
+            .disposed(by: disposeBag)
+        
+        viewModel.completedGoalResult
+            .subscribe(onNext: { [unowned self] res in
+                self.isParentCompleted = res.isGoalCompleted
+                if isParentCompleted {
+                    let vc = CompleteGoalViewController()
+                        .then {
+                            $0.viewModel = viewModel
+                            $0.modalPresentationStyle = .overFullScreen
+                            $0.modalTransitionStyle = .crossDissolve
+                        }
+                    self.present(vc, animated: true)
+                }
             })
             .disposed(by: disposeBag)
     }

--- a/Milestone/Milestone/Screens/FillBox/ViewModel/DetailParentViewModel.swift
+++ b/Milestone/Milestone/Screens/FillBox/ViewModel/DetailParentViewModel.swift
@@ -35,6 +35,7 @@ class DetailParentViewModel: BindableViewModel, ServicesGoalList, ServicesDetail
     var popDetailParentVC = BehaviorRelay(value: false)
     var detailGoalList = BehaviorRelay<[DetailGoal]>(value: [])
     var test = BehaviorRelay<[DetailGoal]>(value: [])
+    var completedGoalResult = BehaviorRelay<StateUpdatedDetailGoal>(value: StateUpdatedDetailGoal(isGoalCompleted: false, completedGoalCount: 0))
     // detailGoalList를 정렬한, 테이블뷰에 보여줄 데이터
     lazy var sortedGoalData = BehaviorRelay<[DetailGoal]>(value: sortGoalForCheckList())
     
@@ -95,12 +96,14 @@ extension DetailParentViewModel {
             .disposed(by: bag)
     }
     
+    /// 세부 목표 완료
     func completeDetailGoal() {
         detailGoalCompleteResponse
             .subscribe { [unowned self] result in
                 switch result {
                 case .success(let response):
                     retrieveDetailGoalList()
+                    completedGoalResult.accept(response.data)
                     Logger.debugDescription(response)
                 case .failure(let error):
                     Logger.debugDescription(error)

--- a/Milestone/Milestone/Screens/FillBox/ViewModel/DetailParentViewModel.swift
+++ b/Milestone/Milestone/Screens/FillBox/ViewModel/DetailParentViewModel.swift
@@ -246,6 +246,7 @@ extension DetailParentViewModel {
                 switch result {
                 case .success(let response):
                     retrieveDetailGoalList()
+                    completedGoalResult.accept(response.data) // 삭제하고 받은 응답값 방출
                     Logger.debugDescription(response)
                 case .failure(let error):
                     Logger.debugDescription(error)


### PR DESCRIPTION
## 상세 내용
- #144 
- 상위 목표가 완료될 수 있는 시점인
1. 세부 목표 완료 API 호출 이후
2. 세부 목표 삭제 API 호출 이후에 `response` 값을 가지고 데이터 바인딩 하여 팝업뷰가 `present` 되도록 구현하였다.
- `response` 중 `rewardType`이 그냥 보석의 이미지의 이름(`BLUE_JEWEL_1`)으로 오는데, 이 완료 팝업 뷰에는 보석의 팝업 이미지(`blueStonePopUpVer1`)가 떠야 했다.
->  `JewelPopUpImageStyle`의 enum을 정의하여 보석 이미지 이름과 보석 팝업 이미지의 이름을 매칭시켰다.

## 셀프 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩 컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 오른쪽의 Development에서 이슈와 연결하였는가?
