### PR TITLE
[#154] 보관함의 목표 랜덤 조회를 통해 목표 권유 기능 완성

### DIFF
--- a/Milestone/Milestone.xcodeproj/project.pbxproj
+++ b/Milestone/Milestone.xcodeproj/project.pbxproj
@@ -32,6 +32,9 @@
 		A23E8B9E2A8FF54D0051D135 /* CompleteGoalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23E8B9B2A8FF54C0051D135 /* CompleteGoalViewController.swift */; };
 		A23E8BA02A900EEC0051D135 /* DeleteGoalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23E8B9F2A900EEC0051D135 /* DeleteGoalViewController.swift */; };
 		A23E8BA22A9013610051D135 /* AskOneOfTwoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23E8BA12A9013610051D135 /* AskOneOfTwoView.swift */; };
+		A2400D652AA3891200EB79D6 /* ContentSizedTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2400D642AA3891200EB79D6 /* ContentSizedTableView.swift */; };
+		A2400D662AA3891200EB79D6 /* ContentSizedTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2400D642AA3891200EB79D6 /* ContentSizedTableView.swift */; };
+		A2400D672AA3891200EB79D6 /* ContentSizedTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2400D642AA3891200EB79D6 /* ContentSizedTableView.swift */; };
 		A252C4B52A92B5AB0067B89C /* ParentGoal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A252C4B32A92B5AB0067B89C /* ParentGoal.swift */; };
 		A252C4B62A92B5AB0067B89C /* ParentGoal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A252C4B32A92B5AB0067B89C /* ParentGoal.swift */; };
 		A25988FA2A967C3000C6BDE0 /* UpdateGoalListDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25988F92A967C3000C6BDE0 /* UpdateGoalListDelegate.swift */; };
@@ -317,6 +320,7 @@
 		A23E8B9B2A8FF54C0051D135 /* CompleteGoalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteGoalViewController.swift; sourceTree = "<group>"; };
 		A23E8B9F2A900EEC0051D135 /* DeleteGoalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteGoalViewController.swift; sourceTree = "<group>"; };
 		A23E8BA12A9013610051D135 /* AskOneOfTwoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AskOneOfTwoView.swift; sourceTree = "<group>"; };
+		A2400D642AA3891200EB79D6 /* ContentSizedTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentSizedTableView.swift; sourceTree = "<group>"; };
 		A252C4B32A92B5AB0067B89C /* ParentGoal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentGoal.swift; sourceTree = "<group>"; };
 		A25988F92A967C3000C6BDE0 /* UpdateGoalListDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateGoalListDelegate.swift; sourceTree = "<group>"; };
 		A25988FD2A96915E00C6BDE0 /* ServicesDetailGoal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServicesDetailGoal.swift; sourceTree = "<group>"; };
@@ -620,6 +624,7 @@
 				A2EC47CF2A8A968A00401B03 /* DetailGoalInfoView.swift */,
 				A26509132A8DE1BA00E9A2D7 /* AddDetailGoalStoneView.swift */,
 				A27C9A0F2A8E42B5002C6F44 /* EnterGoalAlarmView.swift */,
+				A2400D642AA3891200EB79D6 /* ContentSizedTableView.swift */,
 			);
 			path = FillBox;
 			sourceTree = "<group>";
@@ -1306,6 +1311,7 @@
 				C9B2CE152A8F514A006289A8 /* APIService.swift in Sources */,
 				C9B2CDD62A8A77F1006289A8 /* CompletionViewModel.swift in Sources */,
 				C9B2CDFF2A8DE365006289A8 /* CompleteView.swift in Sources */,
+				A2400D652AA3891200EB79D6 /* ContentSizedTableView.swift in Sources */,
 				A2B20D942A7ED174001ED73C /* UIImage+.swift in Sources */,
 				A28EDA152A8791F7001A021A /* DetailGoalCollectionViewCell.swift in Sources */,
 				C90DC9822A88854C00241B7C /* OnboardingViewController.swift in Sources */,
@@ -1324,6 +1330,7 @@
 				A289D95D2A9133C7005B7F00 /* PresentDelegate.swift in Sources */,
 				A289D9532A912864005B7F00 /* PointTextStyle.swift in Sources */,
 				A2B969882A85875A00C4903F /* ParentGoalTableViewCell.swift in Sources */,
+				A2400D662AA3891200EB79D6 /* ContentSizedTableView.swift in Sources */,
 				A28EDA122A87808A001A021A /* UIViewController+.swift in Sources */,
 				A2FA58DE2A7F7A3E006ACA2E /* (null) in Sources */,
 				A2248E842A8818AD00EB995A /* DetailGoalTableViewCell.swift in Sources */,
@@ -1397,6 +1404,7 @@
 				A2FC49592A979F850045FE59 /* ResetGoalViewController.swift in Sources */,
 				A22774AF2A977438004AE5D7 /* AMPMStyle.swift in Sources */,
 				A2FA58E72A7F7A55006ACA2E /* (null) in Sources */,
+				A2400D672AA3891200EB79D6 /* ContentSizedTableView.swift in Sources */,
 				A2B969892A85875A00C4903F /* ParentGoalTableViewCell.swift in Sources */,
 				A2D304BF2A854E4000A5BA92 /* FillBoxViewController.swift in Sources */,
 				A289D9442A91241C005B7F00 /* UserDefaultsKeyStyle.swift in Sources */,

--- a/Milestone/Milestone/Core/API/APIRouter.swift
+++ b/Milestone/Milestone/Core/API/APIRouter.swift
@@ -20,6 +20,7 @@ enum APIRouter: URLRequestConvertible {
     case editGoal(id: Int, goal: Goal)
     case recoverGoal(id: Int, goal: Goal)
     case postGoal(goal: CreateParentGoal)
+    case requestRecommendGoal
     
     /// 유저 관련 API 리스트
     case reissue
@@ -42,6 +43,7 @@ enum APIRouter: URLRequestConvertible {
     case authTest
     
     // MARK: - HttpMethod
+    
     /// switch - self 구문으로 각 엔드포인트별 메서드 지정
     private var method: HTTPMethod {
         switch self {
@@ -82,6 +84,8 @@ enum APIRouter: URLRequestConvertible {
         case .postDetailGoal:
             return .post
         case .authTest:
+            return .get
+        case .requestRecommendGoal:
             return .get
         }
     }
@@ -129,6 +133,8 @@ enum APIRouter: URLRequestConvertible {
             return "/goals/\(id)/detail-goals"
         case .authTest:
             return "/token"
+        case .requestRecommendGoal:
+            return "/goals/stored-goals"
         }
     }
     
@@ -213,10 +219,13 @@ enum APIRouter: URLRequestConvertible {
             ]
         case .authTest:
             return nil
+        case .requestRecommendGoal:
+            return nil
         }
     }
     
     // MARK: - URLRequestConvertible
+    
     func asURLRequest() throws -> URLRequest {
         let url = try K.baseUrl.asURL()
         

--- a/Milestone/Milestone/Core/Services/ServicesGoalList.swift
+++ b/Milestone/Milestone/Core/Services/ServicesGoalList.swift
@@ -28,6 +28,8 @@ protocol ServicesGoalList: Service {
     func requestDeleteParentGoal(id: Int) -> Observable<Result<EmptyDataModel, APIError>>
     
     func requestRestoreParentGoal(id: Int, reqBody: Goal) -> Observable<Result<EmptyDataModel, APIError>>
+    
+    func requestRecommendGoal() -> Observable<Result<BaseModel<[ParentGoal]>, APIError>>
 }
 
 extension ServicesGoalList {
@@ -68,5 +70,10 @@ extension ServicesGoalList {
     // 상위 목표 복구
     func requestRestoreParentGoal(id: Int, reqBody: Goal) -> Observable<Result<EmptyDataModel, APIError>> {
         return apiSession.request(.recoverGoal(id: id, goal: reqBody))
+    }
+    
+    // 보관함에 있는 상위 목표 추천
+    func requestRecommendGoal() -> Observable<Result<BaseModel<[ParentGoal]>, APIError>> {
+        return apiSession.request(.requestRecommendGoal)
     }
 }

--- a/Milestone/Milestone/Global/Component/FillBox/ContentSizedTableView.swift
+++ b/Milestone/Milestone/Global/Component/FillBox/ContentSizedTableView.swift
@@ -1,0 +1,24 @@
+//
+//  ContentSizedTableView.swift
+//  Milestone
+//
+//  Created by 서은수 on 2023/09/03.
+//
+
+import UIKit
+
+// MARK: - content size에 맞게 높이를 자동 조절하는 테이블뷰
+
+final class ContentSizedTableView: UITableView {
+    override var contentSize:CGSize {
+        didSet {
+            invalidateIntrinsicContentSize()
+        }
+    }
+
+    override var intrinsicContentSize: CGSize {
+        layoutIfNeeded()
+        return CGSize(width: UIView.noIntrinsicMetric,
+                     height: contentSize.height + adjustedContentInset.top)
+    }
+}

--- a/Milestone/Milestone/Screens/FillBox/View/FillBoxViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/FillBoxViewController.swift
@@ -66,6 +66,14 @@ class FillBoxViewController: BaseViewController, ViewModelBindableType {
         updateParentGoalList()
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            self.checkRecommendViewPresentCondition()
+        }
+    }
+    
     // MARK: - Functions
     
     override func render() {
@@ -152,6 +160,24 @@ class FillBoxViewController: BaseViewController, ViewModelBindableType {
             }
         addParentGoalVC.bind(viewModel: DetailParentViewModel())
         presentCustomModal(addParentGoalVC, height: addParentGoalVC.viewHeight)
+    }
+    
+    /// 목표를 완료한 후인지 + 보관함에 목표가 1개 이상 있는지 확인
+    /// 조건을 만족한다면 목표 권유(추천) 팝업 뷰를 띄운다
+    private func checkRecommendViewPresentCondition() {
+        let storedGoalCount = Int(viewModel.storedGoalCount.value) ?? 3 // 보관함에 있는 목표 개수
+        if UserDefaults.standard.bool(forKey: UserDefaultsKeyStyle.recommendGoalView.rawValue) && storedGoalCount > 0 {
+            let recommendGoalVC = RecommendGoalViewController()
+                .then {
+                    $0.modalTransitionStyle = .crossDissolve
+                    $0.modalPresentationStyle = .overFullScreen
+                    $0.cellNum = (storedGoalCount > 3) ? 3 : storedGoalCount // 최대가 3개 크기
+                }
+            self.present(recommendGoalVC, animated: true)
+            
+            // 저장된 값을 false로 원상 복구
+            UserDefaults.standard.set(false, forKey: UserDefaultsKeyStyle.recommendGoalView.rawValue)
+        }
     }
     
     // MARK: - @objc Functions

--- a/Milestone/Milestone/Screens/FillBox/View/RecommendGoalViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/RecommendGoalViewController.swift
@@ -63,7 +63,7 @@ class RecommendGoalViewController: BaseViewController, ViewModelBindableType {
     // MARK: - Properties
     
     var viewModel: FillBoxViewModel! = FillBoxViewModel()
-    var cellNum = 2
+    var cellNum = 0
     
     // MARK: - Life Cycle
     

--- a/Milestone/Milestone/Screens/FillBox/View/RecommendGoalViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/RecommendGoalViewController.swift
@@ -14,7 +14,7 @@ import Then
 
 // MARK: - 목표 권유 팝업 뷰
 
-class RecommendGoalViewController: BaseViewController {
+class RecommendGoalViewController: BaseViewController, ViewModelBindableType {
     
     // MARK: - Subviews
     
@@ -31,7 +31,7 @@ class RecommendGoalViewController: BaseViewController {
         }
     lazy var guideLabel = UILabel()
         .then {
-            let contentString = "잠깐만요!\n목표를 이룬 당신에게 추천해요\n이 목표들을 다시 해보는건 어때요?"
+            let contentString = "잠깐만요!\n목표를 이룬 당신에게 추천해요\n이 목표들을 다시 해보는 건 어때요?"
             $0.text = contentString
             $0.textColor = .black
             let attributedString: NSMutableAttributedString = NSMutableAttributedString(string: contentString)
@@ -42,14 +42,13 @@ class RecommendGoalViewController: BaseViewController {
             $0.font = .pretendard(.semibold, ofSize: 18)
             $0.textAlignment = .left
         }
-    lazy var recommendGoalTableView = UITableView()
+    lazy var recommendGoalTableView = ContentSizedTableView()
         .then {
             $0.backgroundColor = .white
             $0.separatorStyle = .none
             $0.showsVerticalScrollIndicator = false
             $0.isScrollEnabled = false
             $0.register(cell: ParentGoalTableViewCell.self, forCellReuseIdentifier: ParentGoalTableViewCell.identifier)
-            $0.dataSource = self
             $0.delegate = self
         }
     lazy var goToStorageButton = UIButton()
@@ -62,7 +61,23 @@ class RecommendGoalViewController: BaseViewController {
         }
     
     // MARK: - Properties
+    
+    var viewModel: FillBoxViewModel! = FillBoxViewModel()
+    var cellNum = 2
+    
     // MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        bindViewModel()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        viewModel.retrieveRecommendGoal()
+    }
     
     // MARK: - Functions
     
@@ -72,7 +87,7 @@ class RecommendGoalViewController: BaseViewController {
         
         containerView.snp.makeConstraints { make in
             make.center.equalToSuperview()
-            make.height.equalTo(550)
+            make.height.equalTo(128 + ((8 + 96 + 8) * cellNum) + 8 + 54 + 24)
             make.width.equalTo(342)
         }
         xButton.snp.makeConstraints { make in
@@ -87,7 +102,6 @@ class RecommendGoalViewController: BaseViewController {
         recommendGoalTableView.snp.makeConstraints { make in
             make.top.equalTo(guideLabel.snp.bottom).offset(8)
             make.left.right.equalToSuperview().inset(20)
-            make.height.equalTo((96 + 16) * 3)
         }
         goToStorageButton.snp.makeConstraints { make in
             make.top.equalTo(recommendGoalTableView.snp.bottom).offset(8)
@@ -116,25 +130,27 @@ class RecommendGoalViewController: BaseViewController {
         }
     }
     
+    func bindViewModel() {
+        viewModel.recommendedGoals
+            .bind(to: recommendGoalTableView.rx.items(cellIdentifier: ParentGoalTableViewCell.identifier, cellType: ParentGoalTableViewCell.self)) { _, goal, cell in
+                cell.backgroundColor = .white
+                cell.containerView.layer.shadowColor = UIColor.clear.cgColor
+                cell.containerView.layer.borderWidth = 1
+                cell.containerView.layer.borderColor = UIColor.secondary01.cgColor
+                cell.goalAchievementRateView.completedCount = CGFloat(goal.completedDetailGoalCnt)
+                cell.goalAchievementRateView.totalCount = CGFloat(goal.entireDetailGoalCnt)
+                cell.titleLabel.text = goal.title
+                cell.termLabel.text = "\(goal.startDate) - \(goal.endDate)"
+            }
+            .disposed(by: disposeBag)
+    }
+    
     // MARK: - @objc Functions
 }
 
 // MARK: - UITableViewDelegate, UITableViewDataSource
 
-extension RecommendGoalViewController: UITableViewDelegate, UITableViewDataSource {
-    // 셀(상위 목표) 개수
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        3
-    }
-    // 셀 내용 구성
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: ParentGoalTableViewCell.identifier, for: indexPath) as? ParentGoalTableViewCell else { return UITableViewCell() }
-        cell.backgroundColor = .white
-        cell.containerView.layer.shadowColor = UIColor.clear.cgColor
-        cell.containerView.layer.borderWidth = 1
-        cell.containerView.layer.borderColor = UIColor.secondary01.cgColor
-        return cell
-    }
+extension RecommendGoalViewController: UITableViewDelegate {
     // 셀 높이 설정
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         96 + 16

--- a/Milestone/Milestone/Screens/FillBox/ViewModel/FillBoxViewModel.swift
+++ b/Milestone/Milestone/Screens/FillBox/ViewModel/FillBoxViewModel.swift
@@ -21,6 +21,7 @@ class FillBoxViewModel: BindableViewModel {
     
     var progressGoalCount = BehaviorRelay<String>(value: "0")
     var completedGoalCount = BehaviorRelay<String>(value: "0")
+    var storedGoalCount = BehaviorRelay<String>(value: "0")
     var progressGoals = BehaviorRelay<[ParentGoal]>(value: [])
     var recommendedGoals = BehaviorRelay<[ParentGoal]>(value: [])
     
@@ -45,6 +46,7 @@ extension FillBoxViewModel: ServicesGoalList {
                 case .success(let response):
                     progressGoalCount.accept(String(response.data.counts.PROCESS))
                     completedGoalCount.accept(String(response.data.counts.COMPLETE))
+                    storedGoalCount.accept(String(response.data.counts.STORE))
                 case .failure(let error):
                     Logger.debugDescription(error)
                 }

--- a/Milestone/Milestone/Screens/FillBox/ViewModel/FillBoxViewModel.swift
+++ b/Milestone/Milestone/Screens/FillBox/ViewModel/FillBoxViewModel.swift
@@ -22,6 +22,7 @@ class FillBoxViewModel: BindableViewModel {
     var progressGoalCount = BehaviorRelay<String>(value: "0")
     var completedGoalCount = BehaviorRelay<String>(value: "0")
     var progressGoals = BehaviorRelay<[ParentGoal]>(value: [])
+    var recommendedGoals = BehaviorRelay<[ParentGoal]>(value: [])
     
     var isLastPage: Bool = false
     var lastGoalId: Int = -1
@@ -82,5 +83,23 @@ extension FillBoxViewModel: ServicesGoalList {
         isLastPage = false
         lastGoalId = -1
         progressGoals.accept([])
+    }
+    
+    /// 보관함에 있는 상위 목표 랜덤 3개 조회
+    func retrieveRecommendGoal() {
+        var recommendGoalResponse: Observable<Result<BaseModel<[ParentGoal]>, APIError>> {
+            requestRecommendGoal()
+        }
+        
+        recommendGoalResponse
+            .subscribe(onNext: { [unowned self] result in
+                switch result {
+                case .success(let response):
+                    recommendedGoals.accept(response.data)
+                case .failure(let error):
+                    Logger.debugDescription(error)
+                }
+            })
+            .disposed(by: bag)
     }
 }

--- a/Milestone/Milestone/Screens/Main/View/MainViewController.swift
+++ b/Milestone/Milestone/Screens/Main/View/MainViewController.swift
@@ -38,12 +38,6 @@ class MainViewController: BaseViewController {
             $0.dataSource = self
         }
     
-    let recommendGoalVC = RecommendGoalViewController()
-        .then {
-            $0.modalTransitionStyle = .crossDissolve
-            $0.modalPresentationStyle = .overFullScreen
-        }
-    
     // MARK: - Properties
     
     var currentPage: Int = 0 {
@@ -71,13 +65,6 @@ class MainViewController: BaseViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.setNavigationBarHidden(true, animated: animated)
-        
-        // 현재 떠있는 VC가 채움함일 때
-        if let currentViewController = pageViewController.viewControllers?.first {
-            if currentViewController == fillBoxVC {
-                checkAfterCompleteGoal()
-            }
-        }
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -86,16 +73,6 @@ class MainViewController: BaseViewController {
     }
     
     // MARK: - Functions
-    
-    /// 목표를 완료한 후인지 확인
-    /// 목표를 완료한 후라면 목표 권유 팝업 뷰를 띄운다
-    private func checkAfterCompleteGoal() {
-        if UserDefaults.standard.bool(forKey: UserDefaultsKeyStyle.recommendGoalView.rawValue) {
-            self.present(recommendGoalVC, animated: true)
-            // 저장된 값을 false로 원상 복구
-            UserDefaults.standard.set(false, forKey: UserDefaultsKeyStyle.recommendGoalView.rawValue)
-        }
-    }
     
     override func render() {
         view.addSubViews([settingButton, segmentedControl, pageViewController.view])


### PR DESCRIPTION
## 상세 내용
- #154 
- 상위 목표 완료 시, 보관함에 있는 목표를 랜덤으로 가져와서 유저에게 목표 재도전을 권유하는 기능 완성
- 랜덤 조회 API 연동
- response로 오는 목표의 개수에 따라 팝업 뷰의 높이를 동적으로 설정
- 보관함에 있는 목표가 1개 이상일 때에만 팝업을 띄우도록 설정

## 기타
- 팝업뷰를 띄우는 VC를 `MainVC`에서 `FillBoxVC`로 변경했습니다. -> 메인에서 해야되는 줄 알았는데 채움함에서 해도 잘 되길래...!
- `FillBoxVC`의 `viewDidAppear`에서 팝업뷰를 띄울지 말지 판단하고 동작을 하는데, 바로 하면 이전 뷰 pop이랑 좀 겹치는 것 같아서 0.3초의 딜레이를 주었습니다.

## 셀프 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩 컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 오른쪽의 Development에서 이슈와 연결하였는가?
