### PR TITLE
[#158] 목표 완료 팝업뷰의 완료함 가기 버튼, 목표 권유 팝업뷰의 보관함 가기 버튼 기능 구현

### DIFF
--- a/Milestone/Milestone.xcodeproj/project.pbxproj
+++ b/Milestone/Milestone.xcodeproj/project.pbxproj
@@ -35,6 +35,9 @@
 		A2400D652AA3891200EB79D6 /* ContentSizedTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2400D642AA3891200EB79D6 /* ContentSizedTableView.swift */; };
 		A2400D662AA3891200EB79D6 /* ContentSizedTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2400D642AA3891200EB79D6 /* ContentSizedTableView.swift */; };
 		A2400D672AA3891200EB79D6 /* ContentSizedTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2400D642AA3891200EB79D6 /* ContentSizedTableView.swift */; };
+		A2400D692AA3C24600EB79D6 /* Notification+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2400D682AA3C24600EB79D6 /* Notification+.swift */; };
+		A2400D6A2AA3C24600EB79D6 /* Notification+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2400D682AA3C24600EB79D6 /* Notification+.swift */; };
+		A2400D6B2AA3C24600EB79D6 /* Notification+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2400D682AA3C24600EB79D6 /* Notification+.swift */; };
 		A252C4B52A92B5AB0067B89C /* ParentGoal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A252C4B32A92B5AB0067B89C /* ParentGoal.swift */; };
 		A252C4B62A92B5AB0067B89C /* ParentGoal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A252C4B32A92B5AB0067B89C /* ParentGoal.swift */; };
 		A25988FA2A967C3000C6BDE0 /* UpdateGoalListDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25988F92A967C3000C6BDE0 /* UpdateGoalListDelegate.swift */; };
@@ -321,6 +324,7 @@
 		A23E8B9F2A900EEC0051D135 /* DeleteGoalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteGoalViewController.swift; sourceTree = "<group>"; };
 		A23E8BA12A9013610051D135 /* AskOneOfTwoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AskOneOfTwoView.swift; sourceTree = "<group>"; };
 		A2400D642AA3891200EB79D6 /* ContentSizedTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentSizedTableView.swift; sourceTree = "<group>"; };
+		A2400D682AA3C24600EB79D6 /* Notification+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification+.swift"; sourceTree = "<group>"; };
 		A252C4B32A92B5AB0067B89C /* ParentGoal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentGoal.swift; sourceTree = "<group>"; };
 		A25988F92A967C3000C6BDE0 /* UpdateGoalListDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateGoalListDelegate.swift; sourceTree = "<group>"; };
 		A25988FD2A96915E00C6BDE0 /* ServicesDetailGoal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServicesDetailGoal.swift; sourceTree = "<group>"; };
@@ -684,6 +688,7 @@
 				A28EDA102A87808A001A021A /* UIViewController+.swift */,
 				C90DC9852A88F0B100241B7C /* UITextField+.swift */,
 				C90DC9892A8922D300241B7C /* NSMutableAttributedString+.swift */,
+				A2400D682AA3C24600EB79D6 /* Notification+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -1309,6 +1314,7 @@
 				A2B20D592A7E4E5C001ED73C /* UIFont+.swift in Sources */,
 				A25988FA2A967C3000C6BDE0 /* UpdateGoalListDelegate.swift in Sources */,
 				C9B2CE152A8F514A006289A8 /* APIService.swift in Sources */,
+				A2400D692AA3C24600EB79D6 /* Notification+.swift in Sources */,
 				C9B2CDD62A8A77F1006289A8 /* CompletionViewModel.swift in Sources */,
 				C9B2CDFF2A8DE365006289A8 /* CompleteView.swift in Sources */,
 				A2400D652AA3891200EB79D6 /* ContentSizedTableView.swift in Sources */,
@@ -1375,6 +1381,7 @@
 				A2FA58E62A7F7A55006ACA2E /* (null) in Sources */,
 				A289D94B2A912616005B7F00 /* WriteRetrospectStyle.swift in Sources */,
 				A22736802A7CE53800D7B3B2 /* MilestoneTests.swift in Sources */,
+				A2400D6A2AA3C24600EB79D6 /* Notification+.swift in Sources */,
 				A2B20D5E2A7E4E68001ED73C /* UIColor+.swift in Sources */,
 				A26416DC2A9959D50073BEA1 /* StorageBoxViewModel.swift in Sources */,
 				A2FA59262A7FD3B1006ACA2E /* UICollectionView+.swift in Sources */,
@@ -1412,6 +1419,7 @@
 				A2FA592F2A7FD433006ACA2E /* NSObject+.swift in Sources */,
 				A2FA591B2A7FD2CF006ACA2E /* BaseViewController.swift in Sources */,
 				A2B20D5F2A7E4E68001ED73C /* UIColor+.swift in Sources */,
+				A2400D6B2AA3C24600EB79D6 /* Notification+.swift in Sources */,
 				A289D9482A91246C005B7F00 /* DayStyle.swift in Sources */,
 				A2FFBC912A94986200039919 /* FillBoxViewModel.swift in Sources */,
 				A2FA59122A7FCFB4006ACA2E /* Encodable+.swift in Sources */,

--- a/Milestone/Milestone/Global/Extension/Notification+.swift
+++ b/Milestone/Milestone/Global/Extension/Notification+.swift
@@ -1,0 +1,14 @@
+//
+//  Notification+.swift
+//  Milestone
+//
+//  Created by 서은수 on 2023/09/03.
+//
+
+import UIKit
+
+// MARK: - Notification의 이름 모음
+
+extension Notification.Name {
+    static let changeSegmentControl = Notification.Name("changeSegmentControl")
+}

--- a/Milestone/Milestone/Screens/FillBox/View/CompleteGoalViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/CompleteGoalViewController.swift
@@ -27,8 +27,7 @@ class CompleteGoalViewController: BaseViewController {
             $0.completeInformationLabel.text = "3번째 보석을 찾으셨네요!"
             $0.completeInformationLabel.textColor = .black
             $0.closeButton.addTarget(self, action: #selector(dismissCompleteGoal), for: .touchUpInside)
-            // TODO: - 추후 코디네이터 패턴 적용하면서 버튼 이벤트 연결
-//            $0.goToButton.addTarget(self, action: #selector(), for: .touchUpInside)
+            $0.goToButton.addTarget(self, action: #selector(goToCompletionBox), for: .touchUpInside)
         }
     
     // MARK: - Properties
@@ -80,5 +79,14 @@ class CompleteGoalViewController: BaseViewController {
     @objc
     private func dismissCompleteGoal() {
         dismiss(animated: true)
+    }
+    
+    /// 팝업 dismiss 하고 detailParentVC도 pop 시켜서 메인으로 이동하고
+    /// Notification 발송해서 완료함 화면을 보여준다
+    @objc
+    private func goToCompletionBox() {
+        self.dismiss(animated: true)
+        self.viewModel?.popDetailParentVC.accept(true)
+        NotificationCenter.default.post(name: .changeSegmentControl, object: 2) // 완료함 인덱스 전송
     }
 }

--- a/Milestone/Milestone/Screens/FillBox/View/RecommendGoalViewController.swift
+++ b/Milestone/Milestone/Screens/FillBox/View/RecommendGoalViewController.swift
@@ -58,6 +58,7 @@ class RecommendGoalViewController: BaseViewController, ViewModelBindableType {
             $0.setTitle("보관함 가기", for: .normal)
             $0.setTitleColor(.primary, for: .normal)
             $0.backgroundColor = .secondary03
+            $0.addTarget(self, action: #selector(goToStorageBox), for: .touchUpInside)
         }
     
     // MARK: - Properties
@@ -146,6 +147,13 @@ class RecommendGoalViewController: BaseViewController, ViewModelBindableType {
     }
     
     // MARK: - @objc Functions
+    
+    /// 팝업 dismiss 하고 Notification 발송해서 보관함 화면을 보여준다
+    @objc
+    private func goToStorageBox() {
+        self.dismiss(animated: true)
+        NotificationCenter.default.post(name: .changeSegmentControl, object: 0) // 보관함 인덱스 전송
+    }
 }
 
 // MARK: - UITableViewDelegate, UITableViewDataSource

--- a/Milestone/Milestone/Screens/Main/View/MainViewController.swift
+++ b/Milestone/Milestone/Screens/Main/View/MainViewController.swift
@@ -60,6 +60,7 @@ class MainViewController: BaseViewController {
         
         changeCurrentPage(control: self.segmentedControl)
         bindingModels()
+        NotificationCenter.default.addObserver(self, selector: #selector(changeSegmentControlAndPage), name: .changeSegmentControl, object: nil)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -129,6 +130,13 @@ class MainViewController: BaseViewController {
     @objc
     private func changeCurrentPage(control: UISegmentedControl) {
         self.currentPage = control.selectedSegmentIndex
+    }
+    
+    @objc
+    private func changeSegmentControlAndPage(_ notification: Notification) {
+        segmentedControl.selectedSegmentIndex = notification.object as! Int
+        changeCurrentPage(control: segmentedControl)
+        segmentedControl.moveUnderlineView()
     }
 }
 


### PR DESCRIPTION
## 상세 내용
- #158 
- 목표 완료 팝업뷰의 완료함 가기 버튼, 목표 권유 팝업뷰의 보관함 가기 버튼 기능 구현 완료
- `NotificationCenter`를 사용하여 `MainVC`에서 `SegmentControl`의 인덱스와 보여지는 VC를 바꿔주었다.

## 셀프 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩 컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 오른쪽의 Development에서 이슈와 연결하였는가?
