### PR TITLE
[#136] 로그인 관련 옵저버블 체이닝 로직 구현 / 화면전환 및 헤더 토큰세팅

### DIFF
--- a/Milestone/Milestone.xcodeproj/project.pbxproj
+++ b/Milestone/Milestone.xcodeproj/project.pbxproj
@@ -234,6 +234,7 @@
 		C90DC9862A88F0B100241B7C /* UITextField+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90DC9852A88F0B100241B7C /* UITextField+.swift */; };
 		C90DC9882A891A8500241B7C /* OnboardingViewControllerLast.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90DC9872A891A8500241B7C /* OnboardingViewControllerLast.swift */; };
 		C90DC98A2A8922D300241B7C /* NSMutableAttributedString+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90DC9892A8922D300241B7C /* NSMutableAttributedString+.swift */; };
+		C91006F92AA0534D000A9C16 /* LoginType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91006F82AA0534D000A9C16 /* LoginType.swift */; };
 		C95A3C9B2A94D08D0028B4ED /* ParentGoal.swift in Sources */ = {isa = PBXBuildFile; fileRef = C95A3C9A2A94D08D0028B4ED /* ParentGoal.swift */; };
 		C95A3C9F2A94E0AC0028B4ED /* CompletionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C95A3C9E2A94E0AC0028B4ED /* CompletionHeaderView.swift */; };
 		C95A3CA12A94EB580028B4ED /* RewardToImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C95A3CA02A94EB580028B4ED /* RewardToImage.swift */; };
@@ -398,6 +399,7 @@
 		C90DC9852A88F0B100241B7C /* UITextField+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+.swift"; sourceTree = "<group>"; };
 		C90DC9872A891A8500241B7C /* OnboardingViewControllerLast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewControllerLast.swift; sourceTree = "<group>"; };
 		C90DC9892A8922D300241B7C /* NSMutableAttributedString+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMutableAttributedString+.swift"; sourceTree = "<group>"; };
+		C91006F82AA0534D000A9C16 /* LoginType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginType.swift; sourceTree = "<group>"; };
 		C95A3C9A2A94D08D0028B4ED /* ParentGoal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentGoal.swift; sourceTree = "<group>"; };
 		C95A3C9E2A94E0AC0028B4ED /* CompletionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionHeaderView.swift; sourceTree = "<group>"; };
 		C95A3CA02A94EB580028B4ED /* RewardToImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardToImage.swift; sourceTree = "<group>"; };
@@ -588,6 +590,7 @@
 				C9040FD72A93CE7D00270E94 /* KeychainKeyList.swift */,
 				C95A3CA02A94EB580028B4ED /* RewardToImage.swift */,
 				A298E9582A9968B000EC0067 /* JewelPopUpImageStyle.swift */,
+				C91006F82AA0534D000A9C16 /* LoginType.swift */,
 			);
 			path = Enum;
 			sourceTree = "<group>";
@@ -1204,6 +1207,7 @@
 				A2B969872A85875A00C4903F /* ParentGoalTableViewCell.swift in Sources */,
 				C95A3C9B2A94D08D0028B4ED /* ParentGoal.swift in Sources */,
 				C9B2CE172A8F5267006289A8 /* APIRouter.swift in Sources */,
+				C91006F92AA0534D000A9C16 /* LoginType.swift in Sources */,
 				A2C98F162A8BA6F0009B5579 /* RoundedButton.swift in Sources */,
 				A289D9462A91246C005B7F00 /* DayStyle.swift in Sources */,
 				A2FA58D12A7F7A1F006ACA2E /* (null) in Sources */,

--- a/Milestone/Milestone/Core/API/APISession.swift
+++ b/Milestone/Milestone/Core/API/APISession.swift
@@ -43,6 +43,7 @@ struct APISession: APIService {
                 }
                 
                 observer.onNext(.success(decoded))
+                observer.onCompleted()
             }
             
             return Disposables.create {

--- a/Milestone/Milestone/Global/Enum/LoginType.swift
+++ b/Milestone/Milestone/Global/Enum/LoginType.swift
@@ -1,0 +1,13 @@
+//
+//  LoginType.swift
+//  Milestone
+//
+//  Created by 박경준 on 2023/08/31.
+//
+
+import Foundation
+
+enum LoginType {
+    case kakao
+    case apple
+}

--- a/Milestone/Milestone/Global/Utils/KeychainManager.swift
+++ b/Milestone/Milestone/Global/Utils/KeychainManager.swift
@@ -96,8 +96,8 @@ class KeychainManager {
         }
     }
     
-    func saveItem<T: Encodable>(
-        _ item: T,
+    func saveItem(
+        _ item: String,
         itemClass: ItemClass,
         key: String,
         attributes: ItemAttributes? = nil) throws {
@@ -127,10 +127,10 @@ class KeychainManager {
             }
         }
     
-    func retrieveItem<T: Decodable>(
+    func retrieveItem(
         ofClass itemClass: ItemClass,
         key: String, attributes:
-        ItemAttributes? = nil) throws -> T {
+        ItemAttributes? = nil) throws -> String {
             
             // 1
             var query: KeychainDictionary = [
@@ -167,11 +167,11 @@ class KeychainManager {
             }
             
             // 7
-            return try JSONDecoder().decode(T.self, from: data)
+            return try JSONDecoder().decode(String.self, from: data)
         }
     
-    func updateItem<T: Encodable>(
-        with item: T,
+    func updateItem(
+        with item: String,
         ofClass itemClass: ItemClass,
         key: String,
         attributes: ItemAttributes? = nil) throws {
@@ -229,7 +229,7 @@ class KeychainManager {
 extension KeychainManager: ReactiveCompatible {}
 
 extension Reactive where Base: KeychainManager {
-    func saveItem<T: Encodable>( _ item: T, itemClass: ItemClass, key: String, attributes: ItemAttributes? = nil) -> Observable<Void> {
+    func saveItem(_ item: String, itemClass: ItemClass, key: String, attributes: ItemAttributes? = nil) -> Observable<Void> {
         return Observable.create({ observer -> Disposable in
             do {
                 try self.base.saveItem(item, itemClass: itemClass, key: key)
@@ -248,10 +248,10 @@ extension Reactive where Base: KeychainManager {
         })
     }
     
-    func retrieveItem<T: Decodable>(ofClass itemClass: ItemClass, key: String, attributes: ItemAttributes? = nil) -> Observable<T> {
+    func retrieveItem(ofClass itemClass: ItemClass, key: String, attributes: ItemAttributes? = nil) -> Observable<String> {
         return Observable.create({ observer -> Disposable in
             do {
-                let result: T = try self.base.retrieveItem(ofClass: itemClass, key: key)
+                let result: String = try self.base.retrieveItem(ofClass: itemClass, key: key)
                 observer.onNext(result)
                 observer.onCompleted()
             } catch {
@@ -262,7 +262,7 @@ extension Reactive where Base: KeychainManager {
         })
     }
     
-    func updateItem<T: Encodable>( with item: T, ofClass itemClass: ItemClass, key: String, attributes: ItemAttributes? = nil) -> Observable<Void> {
+    func updateItem(with item: String, ofClass itemClass: ItemClass, key: String, attributes: ItemAttributes? = nil) -> Observable<Void> {
         return Observable.create({ observer -> Disposable in
             do {
                 try self.base.updateItem(with: item, ofClass: itemClass, key: key)

--- a/Milestone/Milestone/Screens/Onboarding/View/LoginViewController.swift
+++ b/Milestone/Milestone/Screens/Onboarding/View/LoginViewController.swift
@@ -169,7 +169,7 @@ class LoginViewController: BaseViewController {
                 if UserApi.isKakaoTalkLoginAvailable() {
                     UserApi.shared.rx.loginWithKakaoTalk()
                         .subscribe(onNext: { [weak self] _ in
-                            self?.viewModel.kakaoLogin()
+                            self?.viewModel.loginWith(provider: .kakao)
                         }, onError: {error in
                             print(error)
                         })
@@ -213,9 +213,8 @@ extension LoginViewController: ASAuthorizationControllerDelegate {
         switch authorization.credential {
         case let appleIDCredential as ASAuthorizationAppleIDCredential:
             
-            viewModel.appleUserIdSubject
-                .onNext(appleIDCredential.user)
-            viewModel.appleLogin()
+            viewModel.appleUserId = appleIDCredential.user
+            viewModel.loginWith(provider: .apple)
             
         case let passwordCredential as ASPasswordCredential:
             print(passwordCredential)

--- a/Milestone/Milestone/Screens/Onboarding/ViewModel/OnboardingViewModel.swift
+++ b/Milestone/Milestone/Screens/Onboarding/ViewModel/OnboardingViewModel.swift
@@ -40,12 +40,9 @@ class OnboardingViewModel: BindableViewModel {
                 .flatMapLatest { [unowned self] in
                     self.saveToken(result: $0)
                 }
-                .subscribe(onNext: {
-                    // MARK: 로그인 실패 관련 모달 띄우기
-                    if !$0 {
-                        
-                    }
-                },onCompleted: { [unowned self] in
+                .subscribe(onError: {
+                    print($0)
+                }, onCompleted: { [unowned self] in
                     self.loginCoordinator?.coordinateToOnboarding()
                 })
                 .disposed(by: bag)
@@ -53,12 +50,10 @@ class OnboardingViewModel: BindableViewModel {
             fcmObservable
                 .flatMapLatest { [unowned self] in self.kakaoLogin(fcmToken: $0) }
                 .flatMapLatest { [unowned self] in self.saveToken(result: $0) }
-                .subscribe(onNext: {
-                    // MARK: 로그인 실패 관련 모달 띄우기
-                    if !$0 {
-                        
-                    }
-                },onCompleted: { [unowned self] in
+                .subscribe(onError: {
+                    // MARK: 에러처리 필요
+                    print($0)
+                }, onCompleted: { [unowned self] in
                     self.loginCoordinator?.coordinateToOnboarding()
                 })
                 .disposed(by: bag)
@@ -85,8 +80,8 @@ class OnboardingViewModel: BindableViewModel {
                 .saveItem(response.data.refreshToken, itemClass: .password, key: KeychainKeyList.refreshToken.rawValue)
             return accessTokenObservable.concat(refreshTokenObservable)
                 .map { true }
-        case .failure:
-            return Observable.just(false)
+        case .failure(let error):
+            return Observable.error(error)
         }
     }
 }

--- a/Milestone/Milestone/Screens/Onboarding/ViewModel/OnboardingViewModel.swift
+++ b/Milestone/Milestone/Screens/Onboarding/ViewModel/OnboardingViewModel.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 import KakaoSDKUser
+import RxCocoa
 import RxSwift
 import RxKakaoSDKUser
 
@@ -15,111 +16,78 @@ class OnboardingViewModel: BindableViewModel {
     
     var bag = DisposeBag()
     var apiSession: APIService = APISession()
-    
-    let idSubject = PublishSubject<String>()
-    let tokenSubject = PublishSubject<Token>()
     var loginCoordinator: LoginFlow?
     
-    let appleUserIdSubject = PublishSubject<String>()
+    /// FCM 토큰 옵저버블
+    let fcmObservable = KeychainManager.shared.rx
+        .retrieveItem(ofClass: .password, key: KeychainKeyList.fcmToken.rawValue)
     
-    func kakaoLogin() {
-        let fcmObservable = KeychainManager.shared.rx
-            .retrieveItem(ofClass: .password, key: KeychainKeyList.fcmToken.rawValue)
-            .compactMap { $0 as String }
-        
-        UserApi.shared.rx.me()
-            .subscribe(onSuccess: { [unowned self] in
-                guard let id = $0.id else { return }
-                self.idSubject.onNext("\(id)")
-            })
-            .disposed(by: bag)
-        
-        Observable.combineLatest(idSubject.asObservable(), fcmObservable) { [unowned self] userId, fcmToken in
-            self.requestToken(provider: "kakao", userId: userId, fcmToken: fcmToken)
+    /// 소셜로그인 id값 프로퍼티
+    let kakaoUserId = UserApi.shared.rx.me()
+        .asObservable()
+        .compactMap { $0.id }
+        .map { String($0) }
+    var appleUserId: String!
+    
+    /// 로그인 진행
+    /// 1. 프로바이더에 따라 로그인 함수 호출
+    /// 2. 로그인 함수 내에서 토큰 저장함수 재호출
+    func loginWith(provider: LoginType) {
+        switch provider {
+        case .apple:
+            fcmObservable
+                .flatMapLatest { [unowned self] in self.requestToken(provider: "apple", userId: appleUserId, fcmToken: $0)}
+                .flatMapLatest { [unowned self] in
+                    self.saveToken(result: $0)
+                }
+                .subscribe(onNext: {
+                    // MARK: 로그인 실패 관련 모달 띄우기
+                    if !$0 {
+                        
+                    }
+                },onCompleted: { [unowned self] in
+                    self.loginCoordinator?.coordinateToOnboarding()
+                })
+                .disposed(by: bag)
+        case .kakao:
+            fcmObservable
+                .flatMapLatest { [unowned self] in self.kakaoLogin(fcmToken: $0) }
+                .flatMapLatest { [unowned self] in self.saveToken(result: $0) }
+                .subscribe(onNext: {
+                    // MARK: 로그인 실패 관련 모달 띄우기
+                    if !$0 {
+                        
+                    }
+                },onCompleted: { [unowned self] in
+                    self.loginCoordinator?.coordinateToOnboarding()
+                })
+                .disposed(by: bag)
         }
-        .flatMap { $0 }
-        .subscribe(onNext: { [unowned self] result in
-            switch result {
-            case .success(let response):
-                self.tokenSubject.onNext(response.data)
-            case .failure(let error):
-                print(error)
-            }
-        })
-        .disposed(by: bag)
-        
-        let mergedObservable = Observable.of(
-            tokenSubject
-                .map {
-                    KeychainManager.shared.rx
-                        .saveItem($0.accessToken, itemClass: .password, key: KeychainKeyList.accessToken.rawValue)
-                }
-                .subscribe(onNext: {
-                    $0.subscribe(onCompleted: {
-                        print("completed")
-                    })
-                    .dispose()
-                })
-            ,
-            tokenSubject
-                .map {
-                    KeychainManager.shared.rx
-                        .saveItem($0.refreshToken, itemClass: .password, key: KeychainKeyList.refreshToken.rawValue)
-                }
-                .subscribe(onNext: {
-                    $0.subscribe(onCompleted: {
-                        print("completed2")
-                    })
-                    .dispose()
-                })
-        )
-        
-        Observable<any Disposable>
-            .merge()
-            .subscribe(onCompleted: { [weak self] in
-                guard let self = self else { return }
-                self.loginCoordinator?.coordinateToOnboarding()
-            })
-            .disposed(by: bag)
     }
     
-    func appleLogin() {
-        let fcmObservable = KeychainManager.shared.rx
-            .retrieveItem(ofClass: .password, key: KeychainKeyList.fcmToken.rawValue)
-            .compactMap { $0 as String }
-        
-        Observable.combineLatest(fcmObservable, appleUserIdSubject.asObservable()) { [unowned self]  fcm, userId in
-            self.requestToken(provider: "apple", userId: userId, fcmToken: fcm)
-        }
-        .flatMap { $0 }
-        .subscribe(onNext: { [unowned self] result in
-            switch result {
-            case .success(let response):
-                tokenSubject.onNext(response.data)
-            case .failure(let error):
-                print(error)
+    func kakaoLogin(fcmToken: String) -> Observable<Result<BaseModel<Token>, APIError>> {
+        kakaoUserId
+            .flatMap { [unowned self] in
+                self.requestToken(provider: "kakao", userId: $0, fcmToken: fcmToken)
             }
-        })
-        .disposed(by: bag)
-        
-        let mergedObservable = Observable.of(
-            tokenSubject
-                .map {
-                    KeychainManager.shared.rx
-                        .saveItem($0.accessToken, itemClass: .password, key: KeychainKeyList.accessToken.rawValue)
-                },
-            tokenSubject
-                .map {
-                    KeychainManager.shared.rx
-                        .saveItem($0.refreshToken, itemClass: .password, key: KeychainKeyList.refreshToken.rawValue)
-                })
-        
-        Observable.merge(mergedObservable)
-            .subscribe(onCompleted: { [weak self] in
-                guard let self = self else { return }
-                self.loginCoordinator?.coordinateToOnboarding()
-            })
-            .disposed(by: bag)
+    }
+    
+    func appleLogin(fcmToken: String) -> Observable<Result<BaseModel<Token>, APIError>> {
+        self.requestToken(provider: "apple", userId: appleUserId, fcmToken: fcmToken)
+    }
+    
+    func saveToken(result: Result<BaseModel<Token>, APIError>) -> Observable<Bool> {
+        switch result {
+        case .success(let response):
+            let accessTokenObservable = KeychainManager.shared.rx
+                .saveItem(response.data.accessToken, itemClass: .password, key: KeychainKeyList.accessToken.rawValue)
+            let refreshTokenObservable = KeychainManager.shared.rx
+                .saveItem(response.data.refreshToken, itemClass: .password, key: KeychainKeyList.refreshToken.rawValue)
+            return accessTokenObservable.concat(refreshTokenObservable)
+                .map { true }
+        case .failure:
+            return Observable.just(false)
+        }
     }
 }
 


### PR DESCRIPTION
## 상세 내용

로그인 화면에서 API 통신은 정상적으로 되는데, 화면 전환이 자꾸 안먹히는 문제때문에 서치하느라 시간이 좀 많이 소요되었네요 🥲
문제 상황은 다음과 같았습니다.

1. 로그인 버튼 (카카오, 애플) 탭 후 뷰모델에 정의된 로그인 관련 APISession  함수를 호출합니다.
2. 온보딩 화면으로의 전환이 반드시 **토큰 발급 이후에** 이루어져야 하므로 토큰 발급때까지 비동기적으로 화면 전환을 대기하다가, Result 타입의 Success 케이스 혹은 Failure 케이스로 분류된 시점 이후에 새롭게 분기처리를 진행해야 합니다.
3. 기존에는 flatMap 연산자를 써서 requestToken 함수 호출을 통해 리턴되는 result 옵저버블을 단순 처리했었는데, 이렇게 되면 코드가 동기적으로 동작하게 되어 실상 flatMap 내에서는 별 동작을 하지 못하는 상황이 연출됩니다.

예를 들어 ...
```swift
var a = 1
DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
  a += 1
}
print(a)
```
위 코드를 호출하면 `a` 변수의 값이 2가 아닌 1로 호출되는 것과 마찬가지로, flatMap의 단순 나열은 그 자체로 비동기적인 동작을 처리하지 못하게 됩니다.

## 코드 개선
`flatMap` 연산자를 `flatMapLatest`로 교체하여, HTTP 통신을 통해 응답이 오는 이벤트를 매번 구독자에게 새롭게 전달하도록 수정했습니다.
정상적으로 다음 연산자 `flatMapLatest(self.saveToken())`로 넘어가 토큰 통신 완료 이후에 가장 최신 이벤트에 대해서만 해당 함수를 호출하도록 동일하게 연산자 수정을 `flatMap`에서 `flatMapLatest`로 수정하였습니다.

`saveToken` 함수를 보면
```swift
func saveToken(result: Result<BaseModel<Token>, APIError>) -> Observable<Bool> {
    switch result {
    case .success(let response):
        let accessTokenObservable = KeychainManager.shared.rx
            .saveItem(response.data.accessToken, itemClass: .password, key: KeychainKeyList.accessToken.rawValue)
        let refreshTokenObservable = KeychainManager.shared.rx
            .saveItem(response.data.refreshToken, itemClass: .password, key: KeychainKeyList.refreshToken.rawValue)
        return accessTokenObservable.concat(refreshTokenObservable)
            .map { true }
    case .failure:
        return Observable.just(false)
    }
}
```
requestToken 함수를 통해 전달받은 값을 분기처리하고, 각 케이스에 따라 불리언 옵저버블을 리턴하도록 구현해두었습니다. 

모든 통신이 끝나는 시점에 `APISession` 내의 `request` 제네릭 함수에 `observer.onCompleted()` 옵저버 컴플리트 이벤트를 방출하는 코드를 추가하였고 최종적으로 옵저버블 체이닝의 화면 전환 조건을 `onCompleted` 클로저가 호출되는 시점으로 지정해두었습니다.

## 정리
```swift
fcmObservable
    .flatMapLatest { [unowned self] in self.requestToken(provider: "apple", userId: appleUserId, fcmToken: $0)}
    .flatMapLatest { [unowned self] in
        self.saveToken(result: $0)
    }
    .subscribe(onError: {
        print($0)
    }, onCompleted: { [unowned self] in
        self.loginCoordinator?.coordinateToOnboarding()
    })
    .disposed(by: bag)
```
1. fcmObservable -> 키체인 retrieveItem 옵저버블로부터 FCM 토큰값을 불러온다
2. 해당 토큰을 가지고 requestToken 함수를 호출, flatMapLatest를 활용하여 HTTP 통신 완료 이벤트만 받도록 구현
3. HTTP 통신 이후 가져오는 토큰값을 키체인에 저장하는 함수 호출 (해당 함수는 옵저버블 리턴)
4. 리턴된 옵저버블을 구독하여 에러 발생시 에러 관련 모달 추가가 필요하고, 토큰 세팅이 완료된 이후 시점에 온보딩 화면으로 이동하도록 수정

<br/>

## 기타


<br/>

## 셀프 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩 컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 오른쪽의 Development에서 이슈와 연결하였는가?
