### PR TITLE
[#191] Fix 이슈 템플릿 수정

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-template.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-template.md
@@ -1,9 +1,8 @@
 ---
-name: Bug Report Template
-about: DND 9기 1조의 iOS Bug Report 템플릿
+name: Bug Fix Template
+about: Milestone 팀의 Bug Fix 템플릿
 title: "[fix/브랜치명] ~를 수정한다."
-labels: bug, feat
-assignees: EunsuSeo01
+labels: bug, fix
 
 ---
 


### PR DESCRIPTION
## 상세 내용
- #191 
- 전부터 계속 수정하고 싶었던 Fix 이슈 템플릿 Assignee와 Label 수정
- develop에서 main으로 PR 보낼 때 사용할 템플릿도 만드려고 했으나, [링크](https://phillip5094.tistory.com/80)를 확인하니 멀티 템플릿에서는 디폴트 템플릿이 없고, 이슈와 달리 url을 수정해야 다른 버전의 템플릿을 확인할 수 있다고 하여 상의를 통해 만들지 않기로 결정하였다.
- 대신 develop에서 main으로 PR 보낼 때 확인해야 할 사항을 깃허브 Wiki에 추가해 두고 사용하려고 한다!

## 셀프 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩 컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 오른쪽의 Development에서 이슈와 연결하였는가?
